### PR TITLE
Recover Capsomnia after crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Capsomnia will be documented in this file.
 
+## Unreleased
+
+- Restart Capsomnia after crashes through a crash-only LaunchAgent `KeepAlive` rule, then reapply the current Caps Lock sleep state on startup.
+- Documented the manual `sudo pmset -a disablesleep 0` recovery command.
+
 ## 0.3.5 - 2026-07-08
 
 Public release process hardening.

--- a/README.ja.md
+++ b/README.ja.md
@@ -157,6 +157,12 @@ sudoers rule はこの 3 コマンドに限定されています。helper も `o
 pmset -g | grep disablesleep
 ```
 
+通常のスリープ動作へ手動で戻す:
+
+```sh
+sudo pmset -a disablesleep 0
+```
+
 LaunchAgent を再起動する:
 
 ```sh
@@ -165,6 +171,8 @@ launchctl bootstrap "gui/$(id -u)" /Library/LaunchAgents/com.github.fuji-mak.cap
 ```
 
 ソースインストールの場合は、代わりに `$HOME/Library/LaunchAgents/com.github.fuji-mak.capsomnia.plist` を使ってください。
+
+Capsomnia の LaunchAgent は、アプリがクラッシュした場合など正常終了でないときだけアプリを再起動します。起動時に現在の Caps Lock 状態を読み直し、対応するスリープ設定を再適用します。通常の「終了」は正常終了なので、アプリは再起動しません。
 
 helper 権限を確認する:
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Check whether sleep is disabled:
 pmset -g | grep disablesleep
 ```
 
+Restore normal sleep manually:
+
+```sh
+sudo pmset -a disablesleep 0
+```
+
 Restart the LaunchAgent:
 
 ```sh
@@ -165,6 +171,8 @@ launchctl bootstrap "gui/$(id -u)" /Library/LaunchAgents/com.github.fuji-mak.cap
 ```
 
 For source installs, use `$HOME/Library/LaunchAgents/com.github.fuji-mak.capsomnia.plist` instead.
+
+Capsomnia's LaunchAgent restarts the app after a crash or other unsuccessful exit. On startup, Capsomnia reads the current Caps Lock state and reapplies the matching sleep setting. Normal Quit still exits cleanly and does not restart the app.
 
 Check the helper permissions:
 

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -54,6 +54,15 @@ BUILT_APP="$("$ROOT_DIR/scripts/build-app.sh" "$WORK_DIR/$APP_NAME.app")"
 
   <key>RunAtLoad</key>
   <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
 </dict>
 </plist>
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,6 +69,15 @@ cat > "$LAUNCH_AGENT" <<EOF
   <key>RunAtLoad</key>
   <true/>
 
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
   <key>StandardOutPath</key>
   <string>$LOG_DIR/stdout.log</string>
 


### PR DESCRIPTION
## Summary
- add crash-only LaunchAgent KeepAlive rules for package and source installs
- keep normal Quit as a clean exit that does not restart the app
- document manual sleep recovery with sudo pmset -a disablesleep 0

## Verification
- zsh -n scripts/build-pkg.sh scripts/install.sh scripts/notarize-pkg.sh scripts/uninstall.sh
- extracted generated LaunchAgent plists and validated them with plutil -lint
- swift build -c release
- npm run build:site
- git diff --exit-code -- docs/styles.css