### PR TITLE
Bundle uninstall script in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Capsomnia will be documented in this file.
 ## Unreleased
 
 - Restart Capsomnia after crashes through a crash-only LaunchAgent `KeepAlive` rule, then reapply the current Caps Lock sleep state on startup.
+- Bundle the uninstaller inside `Capsomnia.app` so package users can uninstall without cloning the repository.
 - Documented the manual `sudo pmset -a disablesleep 0` recovery command.
 
 ## 0.3.5 - 2026-07-08

--- a/README.ja.md
+++ b/README.ja.md
@@ -115,11 +115,25 @@ git pull
 
 ## アンインストール
 
+パッケージインストールの場合:
+
+```sh
+/Applications/Capsomnia.app/Contents/Resources/uninstall.sh
+```
+
+ソースインストールの場合:
+
+```sh
+~/Applications/Capsomnia.app/Contents/Resources/uninstall.sh
+```
+
+ソース clone から実行する場合は、これと同じです。
+
 ```sh
 ./scripts/uninstall.sh
 ```
 
-LaunchAgent、`/Applications` または `~/Applications` の `Capsomnia.app`、helper、sudoers rule を削除し、通常のスリープ動作へ戻します。
+アンインストーラは LaunchAgent を unload し、Capsomnia を停止し、`/Applications` または `~/Applications` の `Capsomnia.app`、helper、sudoers rule を削除し、通常のスリープ動作へ戻します。管理者認証が必要になることがあります。
 
 ## セキュリティモデル
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,25 @@ The install script overwrites the app bundle, helper, sudoers rule, and LaunchAg
 
 ## Uninstall
 
+For package installs:
+
+```sh
+/Applications/Capsomnia.app/Contents/Resources/uninstall.sh
+```
+
+For source installs:
+
+```sh
+~/Applications/Capsomnia.app/Contents/Resources/uninstall.sh
+```
+
+From a source clone, this is equivalent:
+
 ```sh
 ./scripts/uninstall.sh
 ```
 
-The uninstaller unloads the LaunchAgent, removes `Capsomnia.app` from `/Applications` or `~/Applications`, removes the helper, removes the sudoers rule, and restores normal sleep behavior.
+The uninstaller unloads the LaunchAgent, stops Capsomnia, removes `Capsomnia.app` from `/Applications` or `~/Applications`, removes the helper, removes the sudoers rule, and restores normal sleep behavior. Administrator authentication may be required.
 
 ## Security Model
 

--- a/docs/capsomnia.js
+++ b/docs/capsomnia.js
@@ -59,7 +59,7 @@
       securityHelperTitle: "The helper only ever runs",
       securityHelperBody: "It accepts <code>on</code>, <code>off</code>, and <code>display-sleep</code> and nothing else.",
       securityReq:
-        "Quitting the app, or running <code>./scripts/uninstall.sh</code>, restores normal sleep behavior. Sleep-disabled closed-lid use can increase heat and battery drain — mind airflow, power, and runtime.",
+        "Quitting the app restores normal sleep behavior. Sleep-disabled closed-lid use can increase heat and battery drain — mind airflow, power, and runtime.",
       linksTitle: "Links",
       linkRepoTitle: "GitHub repository",
       linkRepoSub: "Source, issues, releases",
@@ -127,7 +127,7 @@
       securityHelperTitle: "helperが実行するのはこれだけ",
       securityHelperBody: "<code>on</code>、<code>off</code>、<code>display-sleep</code> 以外は受け付けません。",
       securityReq:
-        "アプリを終了するか <code>./scripts/uninstall.sh</code> を実行すると、通常のスリープ動作に戻ります。スリープ無効の蓋閉じ運用は、発熱やバッテリー消費が増えることがあります。通気、電源、実行時間には注意してください。",
+        "アプリを終了すると通常のスリープ動作に戻ります。スリープ無効の蓋閉じ運用は、発熱やバッテリー消費が増えることがあります。通気、電源、実行時間には注意してください。",
       linksTitle: "リンク",
       linkRepoTitle: "GitHubリポジトリ",
       linkRepoSub: "ソースコード、Issue、Release",

--- a/docs/index.html
+++ b/docs/index.html
@@ -361,8 +361,8 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
           </div>
         </div>
         <p class="mt-7 max-w-[760px] text-sm text-[var(--text-faint)]" data-i18n="securityReq">
-          Quitting the app, or running <code>./scripts/uninstall.sh</code>, restores normal sleep behavior.
-          Sleep-disabled closed-lid use can increase heat and battery drain — mind airflow, power, and runtime.
+          Quitting the app restores normal sleep behavior. Sleep-disabled closed-lid use can increase heat and battery
+          drain — mind airflow, power, and runtime.
         </p>
       </section>
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -33,5 +33,6 @@ cd "$ROOT_DIR"
 /usr/bin/install -m 0755 ".build/release/$APP_NAME" "$MACOS_DIR/$APP_NAME"
 /usr/bin/install -m 0644 "resources/Info.plist" "$CONTENTS_DIR/Info.plist"
 /usr/bin/install -m 0644 "resources/AppIcon.icns" "$RESOURCES_DIR/AppIcon.icns"
+/usr/bin/install -m 0755 "scripts/uninstall.sh" "$RESOURCES_DIR/uninstall.sh"
 
 echo "$APP_BUNDLE"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -14,6 +14,7 @@ SUDOERS_PATH="/etc/sudoers.d/capsomnia"
 
 launchctl bootout "gui/$(id -u)" "$LAUNCH_AGENT" 2>/dev/null || true
 launchctl bootout "gui/$(id -u)" "$SYSTEM_LAUNCH_AGENT" 2>/dev/null || true
+/usr/bin/pkill -x "$APP_NAME" 2>/dev/null || true
 
 sudo "$HELPER_PATH" off 2>/dev/null || /usr/bin/pmset -a disablesleep 0 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
- include scripts/uninstall.sh in Capsomnia.app/Contents/Resources/uninstall.sh
- document package/source uninstall paths in README and README.ja
- remove the uninstall command from the landing page copy
- stop any running Capsomnia process during uninstall before removing app/helper files

## Verification
- ./scripts/build-app.sh /private/tmp/Capsomnia-bundle-check.app
- confirmed bundled Resources/uninstall.sh is executable and matches scripts/uninstall.sh
- zsh -n scripts/build-app.sh scripts/build-pkg.sh scripts/install.sh scripts/notarize-pkg.sh scripts/uninstall.sh support/capsomnia-pmset
- node --check docs/capsomnia.js
- npm run build:site
- git diff --exit-code -- docs/styles.css