### PR TITLE
Document offline privacy model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Capsomnia will be documented in this file.
 
 - Restart Capsomnia after crashes through a crash-only LaunchAgent `KeepAlive` rule, then reapply the current Caps Lock sleep state on startup.
 - Bundle the uninstaller inside `Capsomnia.app` so package users can uninstall without cloning the repository.
+- Documented that Capsomnia itself makes no network requests, collects no telemetry, and requires no account.
 - Documented the manual `sudo pmset -a disablesleep 0` recovery command.
 
 ## 0.3.5 - 2026-07-08

--- a/README.ja.md
+++ b/README.ja.md
@@ -139,6 +139,8 @@ git pull
 
 メニューバーアプリ本体は root では動きません。ただしシステムのスリープ設定変更には権限が必要なため、固定 helper を passwordless `sudo` 経由で呼び出します。
 
+Capsomnia 本体はネットワーク通信を行わず、テレメトリを収集せず、アカウントも必要としません。
+
 Capsomnia は Caps Lock の変化をすぐ検知するため、macOS のローカル event tap を使おうとします。macOS 上では Input Monitoring（入力監視）として表示されることがあります。Capsomnia はキーボード入力を記録・送信せず、Caps Lock のフラグだけを確認します。許可されない場合は、1 秒ごとの Caps Lock 状態確認にフォールバックします。
 
 アプリが呼び出せるのは次の 3 コマンドだけです。

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The uninstaller unloads the LaunchAgent, stops Capsomnia, removes `Capsomnia.app
 
 Capsomnia's menu bar app does not run as root. System sleep settings require elevated privileges, so Capsomnia uses a small fixed helper through passwordless `sudo`.
 
+Capsomnia itself does not make network requests, collect telemetry, or require an account.
+
 Capsomnia tries to use a local macOS event tap so Caps Lock changes are detected immediately. macOS may classify this as Input Monitoring. Capsomnia does not record or upload keystrokes; it only checks the Caps Lock flag. If the permission is not granted, Capsomnia falls back to polling the Caps Lock state once per second.
 
 The app can only invoke:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Please include:
 
 Capsomnia's menu bar app runs as the current user. It does not run as root.
 
+Capsomnia itself does not make network requests, collect telemetry, or require an account.
+
 System sleep settings require elevated privileges, so Capsomnia installs a small root-owned helper at:
 
 ```text

--- a/docs/capsomnia.js
+++ b/docs/capsomnia.js
@@ -54,6 +54,7 @@
       securityTitle: "Security model",
       securityLede:
         "The menu bar app runs as the current user — never as root. Changing system sleep settings needs elevated privileges, so Capsomnia uses one small, fixed, root-owned helper through passwordless <code>sudo</code>.",
+      securityOffline: "No network requests. No telemetry. No accounts.",
       securityInvokeTitle: "The app can only invoke",
       securityInvokeBody: "The sudoers rule is limited to these three exact commands.",
       securityHelperTitle: "The helper only ever runs",
@@ -122,6 +123,7 @@
       securityTitle: "安全性の考え方",
       securityLede:
         "メニューバーアプリ本体は現在のユーザーとして動き、rootでは動きません。システムのスリープ設定変更には昇格権限が必要なため、Capsomniaは固定の小さなroot所有helperを、passwordless <code>sudo</code> 経由で呼び出します。",
+      securityOffline: "ネットワーク通信なし。テレメトリなし。アカウント不要。",
       securityInvokeTitle: "アプリが呼べるのはこれだけ",
       securityInvokeBody: "sudoersルールは、この3つの完全一致コマンドだけに限定されています。",
       securityHelperTitle: "helperが実行するのはこれだけ",

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,6 +331,9 @@
             The menu bar app runs as the current user — never as root. Changing system sleep settings needs elevated
             privileges, so Capsomnia uses one small, fixed, root-owned helper through passwordless <code>sudo</code>.
           </p>
+          <p class="mt-4 text-sm font-semibold text-[var(--led)]" data-i18n="securityOffline">
+            No network requests. No telemetry. No accounts.
+          </p>
         </div>
         <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">


### PR DESCRIPTION
## Summary
- add a no-network/no-telemetry/no-account trust line to the landing page security section
- document the same privacy model in README, README.ja, and SECURITY.md
- update the changelog

## Verification
- node --check docs/capsomnia.js
- npm run build:site
- git diff --exit-code -- docs/styles.css
- swift build -c release