### PR TITLE
Prepare Capsomnia 0.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 0.3.6 - 2026-07-08
+
 - Restart Capsomnia after crashes through a crash-only LaunchAgent `KeepAlive` rule, then reapply the current Caps Lock sleep state on startup.
 - Bundle the uninstaller inside `Capsomnia.app` so package users can uninstall without cloning the repository.
 - Documented that Capsomnia itself makes no network requests, collects no telemetry, and requires no account.
 - Documented the manual `sudo pmset -a disablesleep 0` recovery command.
+- Fixed uninstaller fallback recovery so it can restore normal sleep behavior even if the helper path is unavailable.
+- Removed `dist/` prefixes from generated `SHA256SUMS.txt` entries.
+- Prevented AppleDouble `._*` files from being included in package payloads.
 
 ## 0.3.5 - 2026-07-08
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `0.3.5`
+現在のバージョン: `0.3.6`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `0.3.5`
+Current version: `0.3.6`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>0.3.5</string>
+  <string>0.3.6</string>
 
   <key>CFBundleVersion</key>
-  <string>0.3.5</string>
+  <string>0.3.6</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -10,6 +10,13 @@ PKG_SIGN_ID="${PKG_SIGN_ID:-Developer ID Installer: Taketo Fujimaki (ZJZ8627852)
 HELPER_PATH="/Library/PrivilegedHelperTools/capsomnia-pmset"
 LEGACY_HELPER_PATH="/usr/local/sbin/capsomnia-pmset"
 SUDOERS_PATH="/etc/sudoers.d/capsomnia"
+export COPYFILE_DISABLE=true
+PKGBUILD_FILTERS=(
+  --filter '(^|/)\.DS_Store$'
+  --filter '(^|/)\.svn($|/)'
+  --filter '(^|/)CVS($|/)'
+  --filter '(^|/)\._'
+)
 
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$ROOT_DIR/resources/Info.plist")"
 WORK_DIR="$(/usr/bin/mktemp -d)"
@@ -17,6 +24,7 @@ PAYLOAD_ROOT="$WORK_DIR/payload"
 SCRIPTS_DIR="$WORK_DIR/scripts"
 COMPONENT_PLIST="$WORK_DIR/components.plist"
 UNSIGNED_PKG="$DIST_DIR/$APP_NAME-$VERSION-unsigned.pkg"
+SANITIZED_UNSIGNED_PKG="$WORK_DIR/$APP_NAME-$VERSION-sanitized-unsigned.pkg"
 SIGNED_PKG="$DIST_DIR/$APP_NAME-$VERSION.pkg"
 
 cleanup() {
@@ -136,21 +144,47 @@ EOF
 
 /bin/chmod 0755 "$SCRIPTS_DIR/postinstall"
 
-/usr/bin/pkgbuild --analyze --root "$PAYLOAD_ROOT" "$COMPONENT_PLIST"
+/usr/bin/xattr -cr "$PAYLOAD_ROOT" "$SCRIPTS_DIR"
+/usr/bin/find "$PAYLOAD_ROOT" -name '._*' -type f -delete
+
+/usr/bin/env COPYFILE_DISABLE=true /usr/bin/pkgbuild --analyze --root "$PAYLOAD_ROOT" "${PKGBUILD_FILTERS[@]}" "$COMPONENT_PLIST"
 /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" "$COMPONENT_PLIST" 2>/dev/null \
   || /usr/libexec/PlistBuddy -c "Add :0:BundleIsRelocatable bool false" "$COMPONENT_PLIST"
 /usr/libexec/PlistBuddy -c "Set :0:BundleOverwriteAction upgrade" "$COMPONENT_PLIST" 2>/dev/null \
   || /usr/libexec/PlistBuddy -c "Add :0:BundleOverwriteAction string upgrade" "$COMPONENT_PLIST"
 
-/usr/bin/pkgbuild \
+/usr/bin/env COPYFILE_DISABLE=true /usr/bin/pkgbuild \
   --root "$PAYLOAD_ROOT" \
   --scripts "$SCRIPTS_DIR" \
   --component-plist "$COMPONENT_PLIST" \
+  "${PKGBUILD_FILTERS[@]}" \
   --identifier "$LABEL.pkg" \
   --version "$VERSION" \
   --install-location "/" \
   --min-os-version "14.0" \
   "$UNSIGNED_PKG"
+
+EXPANDED_PKG="$WORK_DIR/expanded-pkg"
+PAYLOAD_ARCHIVE="$WORK_DIR/payload.cpio.gz"
+/usr/sbin/pkgutil --expand-full "$UNSIGNED_PKG" "$EXPANDED_PKG"
+/usr/bin/xattr -cr "$EXPANDED_PKG/Payload" "$EXPANDED_PKG/Scripts"
+/usr/bin/find "$EXPANDED_PKG/Payload" -name '._*' -type f -delete
+/usr/bin/mkbom "$EXPANDED_PKG/Payload" "$EXPANDED_PKG/Bom"
+
+payload_file_count="$(/usr/bin/lsbom -s "$EXPANDED_PKG/Bom" | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+payload_install_kbytes="$(/usr/bin/du -sk "$EXPANDED_PKG/Payload" | /usr/bin/awk '{print $1}')"
+/usr/bin/sed -E -i '' \
+  "s/<payload numberOfFiles=\"[0-9]+\" installKBytes=\"[0-9]+\"\\/>/<payload numberOfFiles=\"$payload_file_count\" installKBytes=\"$payload_install_kbytes\"\\/>/" \
+  "$EXPANDED_PKG/PackageInfo"
+
+(
+  cd "$EXPANDED_PKG/Payload"
+  /usr/bin/find . | /usr/bin/cpio -o -H odc -z > "$PAYLOAD_ARCHIVE"
+) 2>/dev/null
+/bin/rm -rf "$EXPANDED_PKG/Payload"
+/bin/mv "$PAYLOAD_ARCHIVE" "$EXPANDED_PKG/Payload"
+/usr/sbin/pkgutil --flatten "$EXPANDED_PKG" "$SANITIZED_UNSIGNED_PKG"
+/bin/mv -f "$SANITIZED_UNSIGNED_PKG" "$UNSIGNED_PKG"
 
 /usr/bin/productsign --sign "$PKG_SIGN_ID" "$UNSIGNED_PKG" "$SIGNED_PKG"
 

--- a/scripts/notarize-pkg.sh
+++ b/scripts/notarize-pkg.sh
@@ -25,8 +25,8 @@ fi
 
 /bin/cp "$PKG_PATH" "$STABLE_PKG"
 (
-  cd "$ROOT_DIR"
-  /usr/bin/shasum -a 256 "dist/$(/usr/bin/basename "$PKG_PATH")" "dist/$(/usr/bin/basename "$STABLE_PKG")" > "$CHECKSUMS_PATH"
+  cd "$ROOT_DIR/dist"
+  /usr/bin/shasum -a 256 "$(/usr/bin/basename "$PKG_PATH")" "$(/usr/bin/basename "$STABLE_PKG")" > "$CHECKSUMS_PATH"
 )
 
 echo "$PKG_PATH"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -16,7 +16,7 @@ launchctl bootout "gui/$(id -u)" "$LAUNCH_AGENT" 2>/dev/null || true
 launchctl bootout "gui/$(id -u)" "$SYSTEM_LAUNCH_AGENT" 2>/dev/null || true
 /usr/bin/pkill -x "$APP_NAME" 2>/dev/null || true
 
-sudo "$HELPER_PATH" off 2>/dev/null || /usr/bin/pmset -a disablesleep 0 2>/dev/null || true
+sudo "$HELPER_PATH" off 2>/dev/null || sudo /usr/bin/pmset -a disablesleep 0 2>/dev/null || true
 
 rm -f "$LAUNCH_AGENT"
 rm -rf "$APP_BUNDLE"


### PR DESCRIPTION
## Summary
- bump Capsomnia to 0.3.6 and move unreleased hardening notes into the release entry
- generate SHA256SUMS.txt from dist using basename-only filenames
- harden uninstall sleep recovery and sanitize package payload/BOM AppleDouble entries

## Verification
- swift build -c release
- npm audit --audit-level=moderate
- npm run build:site
- git diff --exit-code -- docs/styles.css
- zsh -n scripts/build-app.sh scripts/build-pkg.sh scripts/install.sh scripts/notarize-pkg.sh scripts/uninstall.sh support/capsomnia-pmset
- plutil -lint resources/Info.plist
- ./scripts/build-pkg.sh
- pkgutil --payload-files dist/Capsomnia-0.3.6.pkg | rg '^\./.*\.\_' exits 1
- pkgutil --check-signature dist/Capsomnia-0.3.6.pkg
- codesign --verify --deep --strict --verbose=2 expanded Capsomnia.app