### PR TITLE
Prepare Capsomnia 0.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 0.3.8 - 2026-07-11
+
+- Split the first-run onboarding window into two columns so the initial screen is shorter.
+- Reopen Capsomnia after the macOS Input Monitoring "Quit & Reopen" flow when macOS does not bring it back automatically.
+
 ## 0.3.7 - 2026-07-11
 
 - Added onboarding and documentation for Input Monitoring and the macOS background item prompt.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `0.3.7`
+現在のバージョン: `0.3.8`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `0.3.7`
+Current version: `0.3.8`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -165,6 +165,7 @@ private enum PreferenceKey {
     static let didCompleteInitialSetup = "DidCompleteInitialSetup"
     static let forceWelcomeOnNextLaunch = "ForceWelcomeOnNextLaunch"
     static let inputMonitoringRequested = "InputMonitoringRequested"
+    static let inputMonitoringReopenRequestedAt = "InputMonitoringReopenRequestedAt"
 }
 
 enum Preferences {
@@ -219,6 +220,18 @@ enum Preferences {
 
     static func showWelcomeOnNextLaunch() {
         defaults.set(true, forKey: PreferenceKey.forceWelcomeOnNextLaunch)
+    }
+
+    static func markInputMonitoringReopenPending() {
+        defaults.set(Date().timeIntervalSince1970, forKey: PreferenceKey.inputMonitoringReopenRequestedAt)
+    }
+
+    static func consumeFreshInputMonitoringReopenRequest(maxAge: TimeInterval = 600) -> Bool {
+        let requestedAt = defaults.double(forKey: PreferenceKey.inputMonitoringReopenRequestedAt)
+        guard requestedAt > 0 else { return false }
+
+        defaults.removeObject(forKey: PreferenceKey.inputMonitoringReopenRequestedAt)
+        return Date().timeIntervalSince1970 - requestedAt <= maxAge
     }
 
     static func migrateInputMonitoringPreferenceIfNeeded() {

--- a/Sources/Capsomnia/CapsomniaApp.swift
+++ b/Sources/Capsomnia/CapsomniaApp.swift
@@ -53,7 +53,13 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         guard shouldRestoreSleepOnTerminate else { return }
-        log("terminate restore_off")
+
+        let shouldReopen = consumeInputMonitoringReopenRequest()
+        if shouldReopen {
+            scheduleReopenAfterTermination()
+        }
+
+        log("terminate restore_off\(shouldReopen ? " reopen_after_permission_quit" : "")")
         _ = runHelper("off")
     }
 
@@ -257,9 +263,37 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
     private func openInputMonitoring() {
         Preferences.showWelcomeOnNextLaunch()
         Preferences.inputMonitoringRequested = true
+        Preferences.markInputMonitoringReopenPending()
         installEventTap()
         openInputMonitoringSettings()
         log("open_input_monitoring_settings")
+    }
+
+    private func consumeInputMonitoringReopenRequest() -> Bool {
+        let shouldReopen = Preferences.consumeFreshInputMonitoringReopenRequest()
+        if shouldReopen {
+            Preferences.showWelcomeOnNextLaunch()
+        }
+        return shouldReopen
+    }
+
+    private func scheduleReopenAfterTermination() {
+        let bundlePath = Bundle.main.bundleURL.path
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "sleep 1; /usr/bin/open \"$1\"",
+            "capsomnia-reopen",
+            bundlePath
+        ]
+
+        do {
+            try process.run()
+            log("scheduled_reopen_after_permission_quit")
+        } catch {
+            log("schedule_reopen_failed error=\(error.localizedDescription)")
+        }
     }
 
     private func openInputMonitoringSettings() {
@@ -419,9 +453,13 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         for signalNumber in [SIGINT, SIGTERM] {
             let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .main)
             source.setEventHandler { [weak self] in
-                self?.log("signal=\(signalNumber) restore_off")
+                let shouldReopen = self?.consumeInputMonitoringReopenRequest() ?? false
+                if shouldReopen {
+                    self?.scheduleReopenAfterTermination()
+                }
+                self?.log("signal=\(signalNumber) restore_off\(shouldReopen ? " reopen_after_permission_quit" : "")")
                 _ = self?.runHelper("off")
-                exit(0)
+                exit(shouldReopen ? 1 : 0)
             }
             source.resume()
             signalSources.append(source)

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -1,7 +1,8 @@
 import AppKit
 
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
-    private static let contentWidth: CGFloat = 400
+    private static let settingsContentWidth: CGFloat = 400
+    private static let initialContentWidth: CGFloat = 760
 
     private let headerIcon = NSImageView()
     private let titleLabel = brandLabel(size: 21, weight: .bold, color: Brand.text)
@@ -47,6 +48,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let noteLabel = brandLabel(size: 12, color: Brand.textFaint, wraps: true)
     private let doneButton = LEDButton()
 
+    private let rootStack = NSStackView()
+    private let bodyStack = NSStackView()
+    private let leftColumn = NSStackView()
+    private let rightColumn = NSStackView()
+    private var preferencesCard = NSView()
+    private var initialLayoutConstraints: [NSLayoutConstraint] = []
+    private var settingsLayoutConstraints: [NSLayoutConstraint] = []
+
     private let onShowMenuBarIconChange: (Bool) -> Void
     private let onLanguageChange: (AppLanguage) -> Void
     private let onLaunchAtLoginChange: (Bool) -> Void
@@ -71,7 +80,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         self.onFinishInitialSetup = onFinishInitialSetup
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: Self.contentWidth, height: 480),
+            contentRect: NSRect(x: 0, y: 0, width: Self.settingsContentWidth, height: 480),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -129,6 +138,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         doneButton.title = isInitialSetup ? strings.getStarted : strings.done
 
         explainerCard.isHidden = !isInitialSetup
+        permissionsHeading.isHidden = !isInitialSetup
+        permissionsCard.isHidden = !isInitialSetup
         displaySleepOnLidCloseRow.isHidden = isInitialSetup
         displaySleepOnLidCloseDivider.isHidden = isInitialSetup
         openAtLoginRow.isHidden = isInitialSetup
@@ -140,6 +151,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
     func show(initialSetup: Bool) {
         isInitialSetup = initialSetup
+        applyLayout()
         reloadText()
         resizeToFit()
         window?.center()
@@ -152,10 +164,13 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func resizeToFit() {
-        guard let contentView = window?.contentView else { return }
+        guard let window, let contentView = window.contentView else { return }
+        let width = isInitialSetup ? Self.initialContentWidth : Self.settingsContentWidth
+        let currentHeight = max(contentView.bounds.height, 1)
+        window.setContentSize(NSSize(width: width, height: currentHeight))
         contentView.layoutSubtreeIfNeeded()
         let height = contentView.fittingSize.height
-        window?.setContentSize(NSSize(width: Self.contentWidth, height: height))
+        window.setContentSize(NSSize(width: width, height: height))
     }
 
     private func buildContent() {
@@ -178,45 +193,98 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         buildExplainerCard()
         buildPermissionsCard()
 
-        let preferencesCard = buildPreferencesCard()
+        preferencesCard = buildPreferencesCard()
 
         doneButton.onClick = { [weak self] in self?.done() }
         openInputMonitoringButton.onClick = { [weak self] in self?.onOpenInputMonitoring() }
 
-        let stack = NSStackView(views: [
-            header,
-            explainerCard,
-            permissionsHeading,
-            permissionsCard,
-            preferencesHeading,
-            preferencesCard,
-            noteLabel,
-            doneButton
+        configureColumn(rootStack)
+        configureColumn(leftColumn)
+        configureColumn(rightColumn)
+        rootStack.addArrangedSubview(header)
+        rootStack.addArrangedSubview(bodyStack)
+        rootStack.setCustomSpacing(20, after: header)
+        rootStack.translatesAutoresizingMaskIntoConstraints = false
+        bodyStack.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(rootStack)
+        window?.contentView = contentView
+
+        initialLayoutConstraints = [
+            explainerCard.widthAnchor.constraint(equalTo: leftColumn.widthAnchor),
+            permissionsCard.widthAnchor.constraint(equalTo: leftColumn.widthAnchor),
+            preferencesCard.widthAnchor.constraint(equalTo: rightColumn.widthAnchor),
+            noteLabel.widthAnchor.constraint(equalTo: rightColumn.widthAnchor),
+            doneButton.widthAnchor.constraint(equalTo: rightColumn.widthAnchor)
+        ]
+        settingsLayoutConstraints = [
+            preferencesCard.widthAnchor.constraint(equalTo: bodyStack.widthAnchor),
+            doneButton.widthAnchor.constraint(equalTo: bodyStack.widthAnchor)
+        ]
+
+        NSLayoutConstraint.activate([
+            rootStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 28),
+            rootStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -28),
+            rootStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28),
+            rootStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -24),
+            header.widthAnchor.constraint(equalTo: rootStack.widthAnchor),
+            bodyStack.widthAnchor.constraint(equalTo: rootStack.widthAnchor)
         ])
+
+        applyLayout()
+        reloadText()
+    }
+
+    private func applyLayout() {
+        NSLayoutConstraint.deactivate(initialLayoutConstraints + settingsLayoutConstraints)
+        clearArrangedSubviews(bodyStack)
+        clearArrangedSubviews(leftColumn)
+        clearArrangedSubviews(rightColumn)
+
+        if isInitialSetup {
+            leftColumn.addArrangedSubview(explainerCard)
+            leftColumn.addArrangedSubview(permissionsHeading)
+            leftColumn.addArrangedSubview(permissionsCard)
+            leftColumn.setCustomSpacing(8, after: permissionsHeading)
+
+            rightColumn.addArrangedSubview(preferencesHeading)
+            rightColumn.addArrangedSubview(preferencesCard)
+            rightColumn.addArrangedSubview(noteLabel)
+            rightColumn.addArrangedSubview(doneButton)
+            rightColumn.setCustomSpacing(8, after: preferencesHeading)
+
+            bodyStack.orientation = .horizontal
+            bodyStack.alignment = .top
+            bodyStack.distribution = .fillEqually
+            bodyStack.spacing = 16
+            bodyStack.addArrangedSubview(leftColumn)
+            bodyStack.addArrangedSubview(rightColumn)
+            NSLayoutConstraint.activate(initialLayoutConstraints)
+        } else {
+            bodyStack.orientation = .vertical
+            bodyStack.alignment = .leading
+            bodyStack.distribution = .fill
+            bodyStack.spacing = 16
+            bodyStack.addArrangedSubview(preferencesHeading)
+            bodyStack.addArrangedSubview(preferencesCard)
+            bodyStack.addArrangedSubview(doneButton)
+            bodyStack.setCustomSpacing(8, after: preferencesHeading)
+            NSLayoutConstraint.activate(settingsLayoutConstraints)
+        }
+    }
+
+    private func configureColumn(_ stack: NSStackView) {
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 16
-        stack.setCustomSpacing(20, after: header)
-        stack.setCustomSpacing(8, after: permissionsHeading)
-        stack.setCustomSpacing(8, after: preferencesHeading)
         stack.translatesAutoresizingMaskIntoConstraints = false
+    }
 
-        contentView.addSubview(stack)
-        window?.contentView = contentView
-
-        // Full-width children inside the leading-aligned stack.
-        for child in [header, explainerCard, permissionsCard, preferencesCard, noteLabel, doneButton] {
-            child.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+    private func clearArrangedSubviews(_ stack: NSStackView) {
+        for view in stack.arrangedSubviews {
+            stack.removeArrangedSubview(view)
+            view.removeFromSuperview()
         }
-
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 28),
-            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -28),
-            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28),
-            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -24)
-        ])
-
-        reloadText()
     }
 
     private func buildExplainerCard() {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>0.3.7</string>
+  <string>0.3.8</string>
 
   <key>CFBundleVersion</key>
-  <string>0.3.7</string>
+  <string>0.3.8</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary
- bump Capsomnia to 0.3.8
- split first-run onboarding into two columns
- add app-side reopen fallback after the Input Monitoring Quit & Reopen flow

## Verification
- swift build -c release
- git diff --check
- built, notarized, and stapled dist/Capsomnia-0.3.8.pkg