### PR TITLE
Prepare Capsomnia 0.3.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 0.3.10 - 2026-07-11
+
+- Simplified the Input Monitoring screen to a short three-step flow.
+- Moved the Caps Lock on/off explanation to the preferences step.
+- Reduced the background item notice to a single unobtrusive line.
+
 ## 0.3.9 - 2026-07-11
 
 - Require Input Monitoring before completing first-run setup.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `0.3.9`
+現在のバージョン: `0.3.10`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `0.3.9`
+Current version: `0.3.10`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -75,16 +75,15 @@ struct AppStrings {
     let settingsTitle: String
     let initialSettingsNote: String
     let welcomeTitle: String
+    let setupTitle: String
+    let inputMonitoringIntro: String
+    let inputMonitoringSteps: String
     let explainerOnTitle: String
     let explainerOnDesc: String
     let explainerOffTitle: String
     let explainerOffDesc: String
-    let permissionsHeading: String
-    let inputMonitoringTitle: String
-    let inputMonitoringDesc: String
     let openInputMonitoring: String
-    let backgroundItemTitle: String
-    let backgroundItemDesc: String
+    let backgroundItemNote: String
     let preferencesHeading: String
     let done: String
     let getStarted: String
@@ -107,16 +106,15 @@ struct AppStrings {
                 settingsTitle: "Settings",
                 initialSettingsNote: "Open Capsomnia again any time to change these.",
                 welcomeTitle: "Welcome to Capsomnia",
+                setupTitle: "Finish setting up Capsomnia",
+                inputMonitoringIntro: "Capsomnia requires Input Monitoring permission.",
+                inputMonitoringSteps: "1. Select Open Input Monitoring\n2. Turn on Capsomnia\n3. Select Quit & Reopen",
                 explainerOnTitle: "Caps Lock on",
                 explainerOnDesc: "System sleep is disabled — work keeps running, lid open or closed.",
                 explainerOffTitle: "Caps Lock off",
                 explainerOffDesc: "Normal sleep behavior resumes.",
-                permissionsHeading: "Permissions",
-                inputMonitoringTitle: "Input Monitoring",
-                inputMonitoringDesc: "Required to detect Caps Lock changes. Capsomnia does not read typed text. Turn Capsomnia on, then be sure to choose Quit & Reopen when macOS asks. After reopening, setup continues automatically.",
                 openInputMonitoring: "Open Input Monitoring",
-                backgroundItemTitle: "Background Item",
-                backgroundItemDesc: "macOS may show \"Taketo Fujimaki\" as a background item. It lets Capsomnia start at login and recover after crashes. Capsomnia has no network access or telemetry.",
+                backgroundItemNote: "macOS may show “Taketo Fujimaki” as a background item.",
                 preferencesHeading: "Preferences",
                 done: "Done",
                 getStarted: "Get started",
@@ -137,16 +135,15 @@ struct AppStrings {
                 settingsTitle: "設定",
                 initialSettingsNote: "あとからCapsomniaを開けばいつでも変更できます。",
                 welcomeTitle: "Capsomniaへようこそ",
+                setupTitle: "準備を完了してください",
+                inputMonitoringIntro: "Capsomniaを動かすには入力監視の許可が必要です。",
+                inputMonitoringSteps: "1.「入力監視を開く」を押す\n2. Capsomniaをオンにする\n3.「終了して再度開く」を押す",
                 explainerOnTitle: "Caps Lock ON",
                 explainerOnDesc: "システムスリープを無効化。蓋を閉じても作業が走り続けます。",
                 explainerOffTitle: "Caps Lock OFF",
                 explainerOffDesc: "通常のスリープ動作に戻ります。",
-                permissionsHeading: "権限",
-                inputMonitoringTitle: "入力監視",
-                inputMonitoringDesc: "Caps Lockの切り替えを検知するために必要です。入力内容は読みません。Capsomniaをオンにし、macOSに表示される「終了して再度開く」を必ず押してください。再起動後、自動的に次の設定へ進みます。",
                 openInputMonitoring: "入力監視を開く",
-                backgroundItemTitle: "バックグラウンド項目",
-                backgroundItemDesc: "macOSが「Taketo Fujimakiのバックグラウンド項目」を表示することがあります。ログイン時の起動とクラッシュ時の復帰のためです。ネットワーク通信やテレメトリ収集は行いません。",
+                backgroundItemNote: "macOSに“Taketo Fujimakiのバックグラウンド項目”と表示される場合があります。",
                 preferencesHeading: "環境設定",
                 done: "完了",
                 getStarted: "はじめる",

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -18,13 +18,11 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let explainerOffTitle = brandLabel(size: 13, weight: .semibold, color: Brand.text)
     private let explainerOffDesc = brandLabel(size: 12, color: Brand.textDim, wraps: true)
 
-    private let permissionsHeading = brandLabel(size: 11, weight: .semibold, color: Brand.textFaint)
     private let permissionsCard = brandCard()
-    private let inputMonitoringTitle = brandLabel(size: 13, weight: .semibold, color: Brand.text)
-    private let inputMonitoringDesc = brandLabel(size: 12, color: Brand.textDim, wraps: true)
+    private let inputMonitoringIntro = brandLabel(size: 13, weight: .medium, color: Brand.text, wraps: true)
+    private let inputMonitoringSteps = brandLabel(size: 13, color: Brand.textDim, wraps: true)
     private let openInputMonitoringButton = OutlineButton()
-    private let backgroundItemTitle = brandLabel(size: 13, weight: .semibold, color: Brand.text)
-    private let backgroundItemDesc = brandLabel(size: 12, color: Brand.textDim, wraps: true)
+    private let backgroundItemNote = brandLabel(size: 11, color: Brand.textFaint, wraps: true)
 
     private let preferencesHeading = brandLabel(size: 11, weight: .semibold, color: Brand.textFaint)
 
@@ -115,19 +113,17 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
         let isInitialSetup = page != .settings
         window?.title = isInitialSetup ? strings.welcomeTitle : strings.settingsTitle
-        titleLabel.stringValue = isInitialSetup ? strings.welcomeTitle : "Capsomnia"
+        titleLabel.stringValue = page == .permissions ? strings.setupTitle : (isInitialSetup ? strings.welcomeTitle : "Capsomnia")
 
         explainerOnTitle.stringValue = strings.explainerOnTitle
         explainerOnDesc.stringValue = strings.explainerOnDesc
         explainerOffTitle.stringValue = strings.explainerOffTitle
         explainerOffDesc.stringValue = strings.explainerOffDesc
 
-        permissionsHeading.stringValue = strings.permissionsHeading.uppercased()
-        inputMonitoringTitle.stringValue = strings.inputMonitoringTitle
-        inputMonitoringDesc.stringValue = strings.inputMonitoringDesc
+        inputMonitoringIntro.stringValue = strings.inputMonitoringIntro
+        inputMonitoringSteps.stringValue = strings.inputMonitoringSteps
         openInputMonitoringButton.title = strings.openInputMonitoring
-        backgroundItemTitle.stringValue = strings.backgroundItemTitle
-        backgroundItemDesc.stringValue = strings.backgroundItemDesc
+        backgroundItemNote.stringValue = strings.backgroundItemNote
 
         preferencesHeading.stringValue = strings.preferencesHeading.uppercased()
 
@@ -142,8 +138,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         noteLabel.stringValue = strings.initialSettingsNote
         doneButton.title = isInitialSetup ? strings.getStarted : strings.done
 
-        explainerCard.isHidden = page != .permissions
-        permissionsHeading.isHidden = page != .permissions
+        explainerCard.isHidden = page != .initialPreferences
         permissionsCard.isHidden = page != .permissions
         displaySleepOnLidCloseRow.isHidden = false
         displaySleepOnLidCloseDivider.isHidden = false
@@ -215,10 +210,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         window?.contentView = contentView
 
         permissionsLayoutConstraints = [
-            explainerCard.widthAnchor.constraint(equalTo: bodyStack.widthAnchor),
             permissionsCard.widthAnchor.constraint(equalTo: bodyStack.widthAnchor)
         ]
         initialPreferencesLayoutConstraints = [
+            explainerCard.widthAnchor.constraint(equalTo: bodyStack.widthAnchor),
             preferencesCard.widthAnchor.constraint(equalTo: bodyStack.widthAnchor),
             noteLabel.widthAnchor.constraint(equalTo: bodyStack.widthAnchor),
             doneButton.widthAnchor.constraint(equalTo: bodyStack.widthAnchor)
@@ -253,16 +248,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             bodyStack.alignment = .leading
             bodyStack.distribution = .fill
             bodyStack.spacing = 16
-            bodyStack.addArrangedSubview(explainerCard)
-            bodyStack.addArrangedSubview(permissionsHeading)
             bodyStack.addArrangedSubview(permissionsCard)
-            bodyStack.setCustomSpacing(8, after: permissionsHeading)
             NSLayoutConstraint.activate(permissionsLayoutConstraints)
         case .initialPreferences:
             bodyStack.orientation = .vertical
             bodyStack.alignment = .leading
             bodyStack.distribution = .fill
             bodyStack.spacing = 16
+            bodyStack.addArrangedSubview(explainerCard)
             bodyStack.addArrangedSubview(preferencesHeading)
             bodyStack.addArrangedSubview(preferencesCard)
             bodyStack.addArrangedSubview(noteLabel)
@@ -318,21 +311,15 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func buildPermissionsCard() {
-        let inputRow = explainerRow(
-            dot: brandStatusDot(on: true),
-            title: inputMonitoringTitle,
-            desc: inputMonitoringDesc
-        )
-        let backgroundRow = explainerRow(
-            dot: brandStatusDot(on: false),
-            title: backgroundItemTitle,
-            desc: backgroundItemDesc
-        )
-
-        let inner = NSStackView(views: [backgroundRow, inputRow, openInputMonitoringButton])
+        let inner = NSStackView(views: [
+            inputMonitoringIntro,
+            inputMonitoringSteps,
+            openInputMonitoringButton,
+            backgroundItemNote
+        ])
         inner.orientation = .vertical
         inner.alignment = .leading
-        inner.spacing = 14
+        inner.spacing = 16
         inner.translatesAutoresizingMaskIntoConstraints = false
 
         permissionsCard.addSubview(inner)
@@ -341,9 +328,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             inner.trailingAnchor.constraint(equalTo: permissionsCard.trailingAnchor, constant: -16),
             inner.topAnchor.constraint(equalTo: permissionsCard.topAnchor, constant: 16),
             inner.bottomAnchor.constraint(equalTo: permissionsCard.bottomAnchor, constant: -16),
-            inputRow.widthAnchor.constraint(equalTo: inner.widthAnchor),
             openInputMonitoringButton.widthAnchor.constraint(equalTo: inner.widthAnchor),
-            backgroundRow.widthAnchor.constraint(equalTo: inner.widthAnchor)
+            inputMonitoringIntro.widthAnchor.constraint(equalTo: inner.widthAnchor),
+            inputMonitoringSteps.widthAnchor.constraint(equalTo: inner.widthAnchor),
+            backgroundItemNote.widthAnchor.constraint(equalTo: inner.widthAnchor)
         ])
     }
 

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>0.3.9</string>
+  <string>0.3.10</string>
 
   <key>CFBundleVersion</key>
-  <string>0.3.9</string>
+  <string>0.3.10</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary

- simplify the Input Monitoring screen to a short three-step flow
- move the Caps Lock on/off explanation to the preferences step
- reduce the background item notice to one line
- publish version 0.3.10 metadata

## Verification

- `swift build -c release`
- Developer ID app and pkg signatures verified
- Apple notarization accepted (`db9914c4-e666-4513-8ee1-c6f88579e029`)
- stapler validation and Gatekeeper assessment passed