### PR TITLE
Prepare Capsomnia 0.3.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 0.3.11 - 2026-07-11
+
+- Changed the Input Monitoring action to the primary LED-green button style.
+- Prevented the macOS permission alert and Input Monitoring settings from opening simultaneously.
+- Open Input Monitoring settings directly only after a previous permission request.
+
 ## 0.3.10 - 2026-07-11
 
 - Simplified the Input Monitoring screen to a short three-step flow.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `0.3.10`
+現在のバージョン: `0.3.11`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `0.3.10`
+Current version: `0.3.11`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/Sources/Capsomnia/CapsomniaApp.swift
+++ b/Sources/Capsomnia/CapsomniaApp.swift
@@ -269,12 +269,21 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
     }
 
     private func openInputMonitoring() {
+        let hasRequestedBefore = Preferences.inputMonitoringRequested
         Preferences.showWelcomeOnNextLaunch()
         Preferences.inputMonitoringRequested = true
         Preferences.markInputMonitoringReopenPending()
-        installEventTap()
-        openInputMonitoringSettings()
-        log("open_input_monitoring_settings")
+
+        if CGRequestListenEventAccess() {
+            installEventTap()
+            showSettingsWindow(page: .initialPreferences)
+            log("input_monitoring_already_granted")
+        } else if hasRequestedBefore {
+            openInputMonitoringSettings()
+            log("open_input_monitoring_settings_after_previous_request")
+        } else {
+            log("request_input_monitoring_access")
+        }
     }
 
     private func consumeInputMonitoringReopenRequest() -> Bool {

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -21,7 +21,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let permissionsCard = brandCard()
     private let inputMonitoringIntro = brandLabel(size: 13, weight: .medium, color: Brand.text, wraps: true)
     private let inputMonitoringSteps = brandLabel(size: 13, color: Brand.textDim, wraps: true)
-    private let openInputMonitoringButton = OutlineButton()
+    private let openInputMonitoringButton = LEDButton()
     private let backgroundItemNote = brandLabel(size: 11, color: Brand.textFaint, wraps: true)
 
     private let preferencesHeading = brandLabel(size: 11, weight: .semibold, color: Brand.textFaint)

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>0.3.10</string>
+  <string>0.3.11</string>
 
   <key>CFBundleVersion</key>
-  <string>0.3.10</string>
+  <string>0.3.11</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary

- use the LED-green primary style for the Input Monitoring button
- show only the macOS permission alert on the first click
- open Input Monitoring settings directly only after a previous request
- publish version 0.3.11 metadata

## Verification

- `swift build -c release`
- Apple notarization accepted (`3162faa7-8e4b-4b53-9e7e-c4031ceccfe2`)
- stapler validation, Gatekeeper assessment, and package signature verification passed