### PR TITLE
Release Capsomnia 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 1.0.0 - 2026-07-11
+
+First stable release of Capsomnia.
+
+- Toggle system sleep prevention with Caps Lock while keeping normal sleep behavior one switch away.
+- Keep local work running with the MacBook lid closed, with optional display sleep.
+- Provide a signed and notarized installer, a restricted root-owned helper, crash recovery, and a bundled uninstaller.
+- Include a two-step first-run flow for Input Monitoring and user preferences.
+- Make no network requests, collect no telemetry, and require no account.
+
 ## 0.3.11 - 2026-07-11
 
 - Changed the Input Monitoring action to the primary LED-green button style.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `0.3.11`
+現在のバージョン: `1.0.0`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `0.3.11`
+Current version: `1.0.0`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,8 @@
 # Security Policy
 
-## Supported Versions
+## Security Updates
 
-Capsomnia is currently in early public release. Security fixes target the latest `main` branch and tagged releases.
-
-| Version | Supported |
-| --- | --- |
-| 0.3.x | Yes |
-| 0.2.x | No |
-| 0.1.x | No |
+Security fixes are provided only for the latest release. Older releases are not maintained.
 
 ## Reporting a Vulnerability
 

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>0.3.11</string>
+  <string>1.0.0</string>
 
   <key>CFBundleVersion</key>
-  <string>0.3.11</string>
+  <string>1.0.0</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary

- mark Capsomnia as the first stable 1.0.0 release
- update README and bundle version metadata
- document the stable release feature set in the changelog
- clarify that security fixes apply only to the latest release and older releases are not maintained

## Verification

- `swift build -c release`
- Apple notarization accepted (`fabfb864-fe70-40d2-bd95-7dc971d8f9b9`)
- stapler validation, Gatekeeper assessment, and package signature verification passed