### PR TITLE
GitHub PagesのSEOとSearch Console対応を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
       - run: npm run build:site
       - name: Check generated site CSS
         run: git diff --exit-code -- docs/styles.css
+      - name: Validate SEO files
+        run: |
+          test -f docs/robots.txt
+          test -f docs/sitemap.xml
+          test -f docs/googlee5de8ad27617297a.html
+          grep -q 'https://fuji-mak.github.io/Capsomnia/' docs/sitemap.xml
+          grep -q 'Sitemap: https://fuji-mak.github.io/Capsomnia/sitemap.xml' docs/robots.txt
+          grep -q 'google-site-verification: googlee5de8ad27617297a.html' docs/googlee5de8ad27617297a.html
+          grep -q '"@type": "SoftwareApplication"' docs/index.html

--- a/docs/googlee5de8ad27617297a.html
+++ b/docs/googlee5de8ad27617297a.html
@@ -1,0 +1,1 @@
+google-site-verification: googlee5de8ad27617297a.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="CapsomniaはCaps Lockを、蓋を閉じたMacBookでも作業を止めないための物理スイッチに変えるmacOSアプリです。Codex、Claude Code、SSH、ビルド、ダウンロード、放置スクリプト向け。"
     />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <meta name="theme-color" content="#000000" />
     <link rel="canonical" href="https://fuji-mak.github.io/Capsomnia/" />
     <link rel="icon" type="image/svg+xml" href="icon.svg" />
@@ -33,6 +34,50 @@
     <meta name="twitter:description" content="Caps Lockを、蓋を閉じたMacBookでも作業を止めないための物理スイッチに。" />
     <meta name="twitter:image" content="https://fuji-mak.github.io/Capsomnia/og-image.png" />
     <meta name="twitter:image:alt" content="Capsomnia: Caps LockをMacのスリープ防止スイッチに。" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://fuji-mak.github.io/Capsomnia/#website",
+            "url": "https://fuji-mak.github.io/Capsomnia/",
+            "name": "Capsomnia",
+            "description": "Caps Lockを、蓋を閉じたMacBookでも作業を止めないための物理スイッチに変えるmacOSアプリです。",
+            "inLanguage": ["ja", "en"]
+          },
+          {
+            "@type": "SoftwareApplication",
+            "@id": "https://fuji-mak.github.io/Capsomnia/#software",
+            "name": "Capsomnia",
+            "url": "https://fuji-mak.github.io/Capsomnia/",
+            "downloadUrl": "https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg",
+            "codeRepository": "https://github.com/fuji-mak/Capsomnia",
+            "description": "Caps Lockを、蓋を閉じたMacBookでもAIエージェントや長時間ジョブを止めないための物理スイッチに変えるmacOSアプリです。",
+            "applicationCategory": "UtilitiesApplication",
+            "applicationSubCategory": "DeveloperTool",
+            "operatingSystem": "macOS 14 or later",
+            "softwareVersion": "1.0.0",
+            "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
+            "isAccessibleForFree": true,
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "USD"
+            },
+            "author": {
+              "@type": "Person",
+              "name": "Taketo Fujimaki",
+              "url": "https://fuji-maki.me/"
+            },
+            "isPartOf": {
+              "@id": "https://fuji-mak.github.io/Capsomnia/#website"
+            }
+          }
+        ]
+      }
+    </script>
 
     <link rel="stylesheet" href="styles.css?v=20260711-permissions" />
   </head>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://fuji-mak.github.io/Capsomnia/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://fuji-mak.github.io/Capsomnia/</loc>
+    <lastmod>2026-07-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## 概要
- robots.txtとsitemap.xmlを追加
- WebSite / SoftwareApplicationのJSON-LDを追加
- Google Search Consoleの確認ファイルを追加
- SEOファイルの欠落をCIで検査

## 検証
- npm run build:site
- JSON-LDのJSON構文確認
- sitemap.xmlのXML構文確認
- git diff --check