### PR TITLE
Google検索結果を日本語canonicalに固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build:site
+      - run: node --check docs/capsomnia.js
+      - run: node --test Tests/site-language.test.mjs
       - name: Check generated site CSS
         run: git diff --exit-code -- docs/styles.css
       - name: Validate SEO files
@@ -55,3 +57,6 @@ jobs:
           grep -q 'Sitemap: https://fuji-mak.github.io/Capsomnia/sitemap.xml' docs/robots.txt
           grep -q 'google-site-verification: googlee5de8ad27617297a.html' docs/googlee5de8ad27617297a.html
           grep -q '"@type": "SoftwareApplication"' docs/index.html
+          grep -q '"inLanguage": "ja"' docs/index.html
+          grep -q 'return "ja";' docs/capsomnia.js
+          ! grep -q 'Intl.DateTimeFormat' docs/capsomnia.js

--- a/Tests/site-language.test.mjs
+++ b/Tests/site-language.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(new URL("../docs/capsomnia.js", import.meta.url), "utf8");
+
+function renderWithStoredLanguage(storedLanguage) {
+  let savedLanguage = storedLanguage;
+  const description = {
+    content: "",
+    setAttribute(name, value) {
+      if (name === "content") this.content = value;
+    }
+  };
+  const document = {
+    documentElement: { lang: "" },
+    title: "",
+    querySelector(selector) {
+      return selector === 'meta[name="description"]' ? description : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    addEventListener() {}
+  };
+  const window = {
+    localStorage: {
+      getItem() {
+        return savedLanguage;
+      },
+      setItem(_key, value) {
+        savedLanguage = value;
+      }
+    }
+  };
+
+  vm.runInNewContext(source, { console, document, window });
+
+  return {
+    description: description.content,
+    language: document.documentElement.lang,
+    savedLanguage,
+    title: document.title
+  };
+}
+
+test("a fresh visit renders the canonical Japanese page", () => {
+  const result = renderWithStoredLanguage(null);
+
+  assert.equal(result.language, "ja");
+  assert.match(result.title, /Caps LockをMacの物理スリープ防止スイッチに/);
+  assert.match(result.description, /蓋を閉じたMacBook/);
+});
+
+test("an explicit English choice remains available", () => {
+  const result = renderWithStoredLanguage("en");
+
+  assert.equal(result.language, "en");
+  assert.match(result.title, /physical keep-awake switch for macOS/);
+});

--- a/docs/capsomnia.js
+++ b/docs/capsomnia.js
@@ -183,32 +183,10 @@
     var stored = normalizeLanguage(readStoredValue("capsomnia-lang"));
     if (stored) return stored;
 
-    var timeZone = "";
-    try {
-      timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
-    } catch (e) {
-      /* Fall back to browser languages below. */
-    }
-
-    if (timeZone === "Asia/Tokyo") return "ja";
-    if (timeZone) return "en";
-
-    var languages = [];
-    try {
-      if (window.navigator.languages && window.navigator.languages.length) {
-        languages = Array.prototype.slice.call(window.navigator.languages);
-      } else if (window.navigator.language) {
-        languages = [window.navigator.language];
-      }
-    } catch (e) {
-      /* Default to English below. */
-    }
-
-    var hasJapaneseLanguage = languages.some(function (lang) {
-      return String(lang).toLowerCase().indexOf("ja") === 0;
-    });
-
-    return hasJapaneseLanguage ? "ja" : "en";
+    // The canonical URL is Japanese. Geo-adaptive defaults let US-based
+    // crawlers render and index the English variant instead. English remains
+    // available through the explicit language switch and is saved here.
+    return "ja";
   }
 
   var currentLang = detectInitialLanguage();

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
             "url": "https://fuji-mak.github.io/Capsomnia/",
             "name": "Capsomnia",
             "description": "Caps Lockを、蓋を閉じたMacBookでも作業を止めないための物理スイッチに変えるmacOSアプリです。",
-            "inLanguage": ["ja", "en"]
+            "inLanguage": "ja"
           },
           {
             "@type": "SoftwareApplication",
@@ -512,6 +512,6 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
       <p class="text-sm" data-i18n="footerCatch">Macの最も無駄なキーに最高の仕事を与える</p>
     </footer>
 
-    <script src="capsomnia.js?v=20260712-polling"></script>
+    <script src="capsomnia.js?v=20260712-seo-ja"></script>
   </body>
 </html>


### PR DESCRIPTION
## 原因

静的HTMLは日本語でしたが、初回言語をタイムゾーンで切り替えていたため、米国系Googlebotが英語DOM・英語title・英語descriptionをレンダリングしてインデックスしていました。

## 修正

- 保存済み言語がない初回アクセスはcanonicalの日本語で固定
- 明示的にENを選んだユーザーの保存設定は維持
- JSON-LDのinLanguageをjaへ統一
- JSキャッシュバスター更新
- 初回日本語・保存済み英語のNodeテストをCIへ追加
- タイムゾーン自動判定の再混入をCIで検知

## 検証

- node --check docs/capsomnia.js
- node --test Tests/site-language.test.mjs
- npm run build:site
- JSON-LD parse成功