### PR TITLE
Add AssociatedBundleIdentifiers to generated LaunchAgent plists

### DIFF
--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -72,6 +72,11 @@ fi
   <key>Label</key>
   <string>$LABEL</string>
 
+  <key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>$LABEL</string>
+  </array>
+
   <key>ProgramArguments</key>
   <array>
     <string>/Applications/$APP_NAME.app/Contents/MacOS/$APP_NAME</string>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,6 +61,11 @@ cat > "$LAUNCH_AGENT" <<EOF
   <key>Label</key>
   <string>$LABEL</string>
 
+  <key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>$LABEL</string>
+  </array>
+
   <key>ProgramArguments</key>
   <array>
     <string>$APP_BUNDLE/Contents/MacOS/$APP_NAME</string>


### PR DESCRIPTION
Closes #29

システム設定 > 一般 > ログイン項目と機能拡張 で、バックグラウンド項目が開発者名「Taketo Fujimaki」で表示される件（#29）の修正提案です。

- `scripts/build-pkg.sh` / `scripts/install.sh` が生成する LaunchAgent plist に `AssociatedBundleIdentifiers` を追加します（値はアプリの `CFBundleIdentifier` と同値の `$LABEL` を使用）
- macOS 13+ で有効なキーのため、本アプリの最低要件（macOS 14）を満たします
- BTM に新規登録されるマシンでは「Capsomnia.app」＋アプリアイコンで表示される想定です。既存インストールでの部分反映の実測（アイコン・BTM レコードは即時更新、行タイトルのみ旧値が残置）は #29 を参照してください

## 検証 / Verification

- `zsh -n scripts/build-pkg.sh scripts/install.sh`（構文チェック）
- 生成される plist と同内容を `plutil -lint` で検証し、実機の `/Library/LaunchAgents` に手動適用して agent の稼働と BTM レコードへの反映を確認済み（詳細は #29）

---

Adds `AssociatedBundleIdentifiers` to the LaunchAgent plists generated by `scripts/build-pkg.sh` and `scripts/install.sh`, so Background Task Management can attribute the background item to Capsomnia.app instead of falling back to the signing certificate's developer name. Background and on-device verification: #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
