### PR TITLE
Capsomnia 1.0.1 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 1.0.1 - 2026-07-15
+
+- Associate the installed LaunchAgent with the Capsomnia app bundle so new background-item registrations can show the app name and icon instead of falling back to the Developer ID name. Existing macOS registrations may retain their cached label.
+- Add concise usage and safety guidance covering heat, battery drain, normal sleep restoration, critical jobs, backups, and the software warranty boundary.
+- Keep the canonical landing page Japanese for search indexing and move the no-network, no-telemetry, no-account privacy promise closer to the product introduction.
+- Remove unused app and site code and consolidate duplicated internal implementations without intentionally changing behavior.
+
 ## 1.0.0 - 2026-07-12
 
 First stable release of Capsomnia.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `1.0.0`
+現在のバージョン: `1.0.1`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `1.0.0`
+Current version: `1.0.1`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.0",
+            "softwareVersion": "1.0.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>1.0.1</string>
 
   <key>CFBundleVersion</key>
-  <string>1.0.0</string>
+  <string>1.0.1</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## 概要

Capsomnia 1.0.1 のリリースメタデータを更新します。

## 変更内容

- Info.plist のバージョンを 1.0.1 に更新
- README 日英の現在バージョンを更新
- 公開サイトの softwareVersion を更新
- v1.0.0 以降の変更を CHANGELOG に記載
  - バックグラウンド項目とアプリの関連付け
  - 利用上・安全上の注意
  - 日本語canonicalとプライバシー文言の改善
  - デッドコード・重複実装の整理

## 検証

- swift build -c release
- swift test
- npm ci
- npm run build:site
- node --check docs/capsomnia.js
- node --test Tests/site-language.test.mjs
- shell syntax / Info.plist lint
- helper Mach-O / invalid-mode rejection
- unsigned pkg build / version 1.0.1 / root ownership / AppleDouble除去
- pkg内LaunchAgentの AssociatedBundleIdentifiers 確認