### PR TITLE
Add GitHub Sponsors funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: fuji-mak


### PR DESCRIPTION
## Summary\n\n- Add .github/FUNDING.yml with the fuji-mak GitHub Sponsors account\n- Configure Capsomnia for a repository-level Sponsor button\n\n## Notes\n\nThe Sponsorships feature must be enabled in the repository settings for GitHub to display the native Sponsor button.