### PR TITLE
Capsomnia 1.0.2 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 1.0.2 - 2026-07-16
+
+- Keep external displays active in clamshell mode by skipping forced display sleep whenever an online external display is connected. If the display state cannot be determined, Capsomnia now fails safely without requesting display sleep.
+- Add a GitHub Sponsors funding link for users who want to support ongoing development.
+
 ## 1.0.1 - 2026-07-15
 
 - Associate the installed LaunchAgent with the Capsomnia app bundle so new background-item registrations can show the app name and icon instead of falling back to the Developer ID name. Existing macOS registrations may retain their cached label.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `1.0.1`
+現在のバージョン: `1.0.2`
 
 [English README](README.md) · [`Capsomnia.pkg` をダウンロード](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `1.0.1`
+Current version: `1.0.2`
 
 [日本語 README](README.ja.md) · [Download `Capsomnia.pkg`](https://github.com/fuji-mak/Capsomnia/releases/latest/download/Capsomnia.pkg)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.1",
+            "softwareVersion": "1.0.2",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>1.0.1</string>
+  <string>1.0.2</string>
 
   <key>CFBundleVersion</key>
-  <string>1.0.1</string>
+  <string>1.0.2</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## 概要

Capsomnia 1.0.2 のリリースメタデータを更新します。

## 変更内容

- Info.plist のバージョンを 1.0.2 に更新
- README 日英の現在バージョンを更新
- 公開サイトの softwareVersion を更新
- CHANGELOG に以下を記載
  - クラムシェルモードで外部ディスプレイを消さない修正
  - GitHub Sponsorsリンクの追加

## 検証

- swift test（6件成功）
- Release構成のビルド
- npm ci
- npm run build:site
- node --check docs/capsomnia.js
- node --test Tests/site-language.test.mjs（2件成功）
- 生成CSSの差分なし
- shell syntax / Info.plist lint
- helperのMach-O確認
- unsigned pkg build / root ownership / AppleDouble除去
- 実機のクラムシェル環境で外部ディスプレイが点灯を維持することを確認
