### PR TITLE
Refine LP language controls and Chinese README links

### DIFF
--- a/Tests/site-language.test.mjs
+++ b/Tests/site-language.test.mjs
@@ -54,6 +54,18 @@ for (const page of pages) {
     assert.equal((html.match(/class="language-option /g) ?? []).length, pages.length);
     assert.doesNotMatch(html, /lang-switch|lang-btn|hidden sm:inline">Capsomnia/);
 
+    const languageSummaryClasses = html.match(
+      /<summary\s+class="([^"]+)"/
+    )?.[1];
+    assert.ok(languageSummaryClasses);
+    assert.match(languageSummaryClasses, /min-h-\[44px\]/);
+    assert.match(languageSummaryClasses, /min-w-\[68px\]/);
+    assert.match(languageSummaryClasses, /px-3/);
+    assert.doesNotMatch(
+      languageSummaryClasses,
+      /rounded-full|border-\[var\(--border-strong\)\]|bg-\[var\(--surface\)\]/
+    );
+
     for (const alternate of expectedAlternates) assert.ok(html.includes(alternate));
     for (const localePage of pages) {
       assert.ok(html.includes(`href="${localePage.currentHref}"`));
@@ -110,4 +122,17 @@ test("the sitemap lists every localized URL and alternate", () => {
     assert.ok(sitemap.includes(`hreflang="${page.code}" href="${siteUrl}${page.path}"`));
   }
   assert.ok(sitemap.includes(`hreflang="x-default" href="${siteUrl}"`));
+});
+
+test("the Chinese page links to English and Simplified Chinese READMEs", () => {
+  const html = readFileSync(
+    new URL("../docs/zh-hans/index.html", import.meta.url),
+    "utf8"
+  );
+
+  assert.ok(html.includes("/blob/main/README.md"));
+  assert.ok(html.includes("/blob/main/README.zh-Hans.md"));
+  assert.ok(html.includes("README（简体中文）"));
+  assert.ok(html.includes("简体中文文档"));
+  assert.doesNotMatch(html, /\/blob\/main\/README\.ja\.md/);
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@
       <div class="ml-auto flex shrink-0 items-center justify-end gap-1.5 sm:gap-2 lg:gap-3">
         <details class="language-menu relative shrink-0">
           <summary
-            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 rounded-full border border-[var(--border-strong)] bg-[var(--surface)] px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:border-[var(--led)] hover:text-[var(--led)]"
+            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:text-[var(--led)]"
             aria-label="Select language"
           >
             <span>EN</span>

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -129,7 +129,7 @@
       <div class="ml-auto flex shrink-0 items-center justify-end gap-1.5 sm:gap-2 lg:gap-3">
         <details class="language-menu relative shrink-0">
           <summary
-            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 rounded-full border border-[var(--border-strong)] bg-[var(--surface)] px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:border-[var(--led)] hover:text-[var(--led)]"
+            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:text-[var(--led)]"
             aria-label="言語を選択"
           >
             <span>JA</span>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -129,7 +129,7 @@
       <div class="ml-auto flex shrink-0 items-center justify-end gap-1.5 sm:gap-2 lg:gap-3">
         <details class="language-menu relative shrink-0">
           <summary
-            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 rounded-full border border-[var(--border-strong)] bg-[var(--surface)] px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:border-[var(--led)] hover:text-[var(--led)]"
+            class="inline-flex min-h-[44px] min-w-[68px] cursor-pointer list-none items-center justify-center gap-1.5 px-3 py-2 text-xs font-bold text-[var(--text)] transition-colors hover:text-[var(--led)]"
             aria-label="选择语言"
           >
             <span>ZH</span>
@@ -432,12 +432,12 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
           </a>
           <a
             class="flex flex-col gap-1 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] px-5 py-5 no-underline transition hover:-translate-y-0.5 hover:border-[var(--led-deep)]"
-            href="https://github.com/fuji-mak/Capsomnia/blob/main/README.ja.md"
+            href="https://github.com/fuji-mak/Capsomnia/blob/main/README.zh-Hans.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <span class="font-semibold text-[var(--text)]">README（日本語）</span>
-            <span class="text-sm text-[var(--text-faint)]">日文文档</span>
+            <span class="font-semibold text-[var(--text)]">README（简体中文）</span>
+            <span class="text-sm text-[var(--text-faint)]">简体中文文档</span>
           </a>
           <a
             class="flex flex-col gap-1 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] px-5 py-5 no-underline transition hover:-translate-y-0.5 hover:border-[var(--led-deep)]"


### PR DESCRIPTION
## Summary

- remove the persistent pill background and border from the header language control
- keep the existing 44px touch target, 68px occupied width, internal padding, spacing, and keyboard focus indicator
- update the Simplified Chinese LP to link to the English and Simplified Chinese READMEs instead of the Japanese README
- add regression coverage for the unframed control dimensions and Chinese README targets

## Verification

- `npm run build:site`
- `npm test` — 15 tests passed
- desktop visual check at 1280×720
- mobile visual check at 375×812
- checked the open language popover on English and Japanese pages
- checked the four-link section on the Simplified Chinese page

This PR does not change the Cloudflare Worker or language-routing behavior.