### PR TITLE
Capsomnia 1.0.3 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 1.0.3 - 2026-07-18
+
+- Add Simplified Chinese and Korean localizations to the macOS app, README, and website.
+- Replace the app's segmented language control with a compact pop-up menu for English, Japanese, Simplified Chinese, and Korean.
+- Move the official website to `capsomnia.com`, add localized routes, and route first visits by browser language through Cloudflare Workers while preserving redirects from the previous GitHub Pages URL.
+- Refine the README and landing-page download buttons, language navigation, localized metadata, and support links.
+
 ## 1.0.2 - 2026-07-16
 
 - Keep external displays active in clamshell mode by skipping forced display sleep whenever an online external display is connected. If the display state cannot be determined, Capsomnia now fails safely without requesting display sleep.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `1.0.2`
+現在のバージョン: `1.0.3`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `1.0.2`
+현재 버전: `1.0.3`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `1.0.2`
+Current version: `1.0.3`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`1.0.2`
+当前版本：`1.0.3`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.2",
+            "softwareVersion": "1.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.2",
+            "softwareVersion": "1.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.2",
+            "softwareVersion": "1.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.2",
+            "softwareVersion": "1.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>1.0.2</string>
+  <string>1.0.3</string>
 
   <key>CFBundleVersion</key>
-  <string>1.0.2</string>
+  <string>1.0.3</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## 概要

Capsomnia 1.0.3 のリリース準備です。

## 変更内容

- アプリ、README、LPのバージョン表記を1.0.3へ更新
- CHANGELOGに簡体字中国語・韓国語対応、言語プルダウン、capsomnia.comと言語ルーティングを追記
- 4言語のLP構造化データを1.0.3へ更新

## 検証

- `swift test`: 14 tests passed
- `npm test`: 19 tests passed
- `npm run build:site`: 成功、生成CSSに差分なし
- shell script syntax check: 成功
- native helper invalid-mode check: expected exit 64
- `SKIP_SIGNING=true ./scripts/build-pkg.sh`: payload/ownership検証を含め成功

マージ後、Developer ID署名・Apple公証・staple・Gatekeeper検証を通したpkgをGitHub Releaseへ添付します。
