### PR TITLE
Add reachability (Auto) keep-awake mode + battery-floor safety

### DIFF
--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -92,6 +92,9 @@ struct AppStrings {
     let openAtLoginDesc: String
     let displaySleepOnLidClose: String
     let displaySleepOnLidCloseDesc: String
+    let batteryFloorMenu: String
+    let batteryFloorDesc: String
+    let batteryFloorOff: String
     let keyboardShortcut: String
     let keyboardShortcutDesc: String
     let shortcutRecorderPlaceholder: String
@@ -136,6 +139,9 @@ struct AppStrings {
                 openAtLoginDesc: "Launch Capsomnia automatically after you sign in.",
                 displaySleepOnLidClose: "Turn display off when lid closes",
                 displaySleepOnLidCloseDesc: "When Capsomnia is on, let the display sleep after closing the lid only if no external display is connected.",
+                batteryFloorMenu: "Battery floor",
+                batteryFloorDesc: "On battery, allow sleep at or below this level so the battery is never fully drained.",
+                batteryFloorOff: "Off",
                 keyboardShortcut: "Toggle shortcut",
                 keyboardShortcutDesc: "If you’ve assigned Caps Lock to another key, you can use a shortcut to turn Capsomnia on and off. While Capsomnia is on, the green Caps Lock light stays lit.",
                 shortcutRecorderPlaceholder: "Not Set",
@@ -174,6 +180,9 @@ struct AppStrings {
                 openAtLoginDesc: "로그인하면 Capsomnia를 자동으로 실행합니다.",
                 displaySleepOnLidClose: "덮개를 닫을 때 화면 끄기",
                 displaySleepOnLidCloseDesc: "Capsomnia가 켜진 상태에서 덮개를 닫으면 외부 디스플레이가 연결되지 않은 경우에만 화면을 끕니다.",
+                batteryFloorMenu: "배터리 하한",
+                batteryFloorDesc: "배터리 사용 중에는 이 수준 이하에서 잠자기를 허용해 배터리가 완전히 방전되지 않게 합니다.",
+                batteryFloorOff: "끄기",
                 keyboardShortcut: "전환 단축키",
                 keyboardShortcutDesc: "Caps Lock을 다른 키에 할당한 경우에도 원하는 단축키로 Capsomnia를 켜거나 끌 수 있습니다. Capsomnia가 켜져 있는 동안에는 초록색 Caps Lock 표시등이 켜집니다.",
                 shortcutRecorderPlaceholder: "미설정",
@@ -212,6 +221,9 @@ struct AppStrings {
                 openAtLoginDesc: "サインイン後にCapsomniaを自動で起動します。",
                 displaySleepOnLidClose: "蓋を閉じたら画面をオフ",
                 displaySleepOnLidCloseDesc: "Capsomnia ON中は、外部ディスプレイが接続されていない場合のみ、蓋を閉じたら画面を暗くします。",
+                batteryFloorMenu: "バッテリー下限",
+                batteryFloorDesc: "バッテリー駆動時、この残量以下でスリープを許可。電池が完全に尽きるのを防ぎます。",
+                batteryFloorOff: "オフ",
                 keyboardShortcut: "切り替えショートカット",
                 keyboardShortcutDesc: "Caps Lockを別のキーに割り当てている場合でも、お好みのショートカットでCapsomniaをオン／オフできます。Capsomniaがオンの間は、Caps Lockの緑のライトが点灯します。",
                 shortcutRecorderPlaceholder: "未設定",
@@ -250,6 +262,9 @@ struct AppStrings {
                 openAtLoginDesc: "登录后自动启动 Capsomnia。",
                 displaySleepOnLidClose: "合盖时关闭显示屏",
                 displaySleepOnLidCloseDesc: "Capsomnia 开启时，仅在未连接外接显示器的情况下，合盖后让显示屏进入睡眠。",
+                batteryFloorMenu: "电量下限",
+                batteryFloorDesc: "使用电池时，在此电量或以下允许睡眠，避免电池彻底耗尽。",
+                batteryFloorOff: "关闭",
                 keyboardShortcut: "切换快捷键",
                 keyboardShortcutDesc: "即使已将 Caps Lock 分配给其他按键，也可以使用自定义快捷键开启或关闭 Capsomnia。Capsomnia 开启期间，绿色 Caps Lock 指示灯会保持亮起。",
                 shortcutRecorderPlaceholder: "未设置",
@@ -284,6 +299,8 @@ private enum PreferenceKey {
     static let language = "Language"
     static let launchAtLogin = "LaunchAtLogin"
     static let displaySleepOnLidClose = "DisplaySleepOnLidClose"
+    static let batteryFloorEnabled = "BatteryFloorEnabled"
+    static let batteryFloorPercent = "BatteryFloorPercent"
     static let shortcutKeyCode = "ShortcutKeyCode"
     static let shortcutModifiers = "ShortcutModifiers"
     static let shortcutKey = "ShortcutKey"
@@ -301,6 +318,8 @@ enum Preferences {
             PreferenceKey.language: AppLanguage.defaultLanguage.rawValue,
             PreferenceKey.launchAtLogin: true,
             PreferenceKey.displaySleepOnLidClose: true,
+            PreferenceKey.batteryFloorEnabled: false,
+            PreferenceKey.batteryFloorPercent: 15,
             PreferenceKey.didCompleteInitialSetup: false,
             PreferenceKey.forceWelcomeOnNextLaunch: false
         ])
@@ -332,6 +351,20 @@ enum Preferences {
     static var displaySleepOnLidClose: Bool {
         get { defaults.bool(forKey: PreferenceKey.displaySleepOnLidClose) }
         set { defaults.set(newValue, forKey: PreferenceKey.displaySleepOnLidClose) }
+    }
+
+    static var batteryFloorEnabled: Bool {
+        get { defaults.bool(forKey: PreferenceKey.batteryFloorEnabled) }
+        set { defaults.set(newValue, forKey: PreferenceKey.batteryFloorEnabled) }
+    }
+
+    /// Battery percentage at or below which keep-awake is released (0 = fall back to 15).
+    static var batteryFloorPercent: Int {
+        get {
+            let value = defaults.integer(forKey: PreferenceKey.batteryFloorPercent)
+            return (value >= 5 && value <= 90) ? value : 15
+        }
+        set { defaults.set(newValue, forKey: PreferenceKey.batteryFloorPercent) }
     }
 
     static var keyboardShortcut: KeyboardShortcut? {

--- a/Sources/Capsomnia/CapsomniaApp.swift
+++ b/Sources/Capsomnia/CapsomniaApp.swift
@@ -17,6 +17,12 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
     private var shouldRestoreSleepOnTerminate = true
     private var pollingTimer: Timer?
     private var pendingCapsLockOffWorkItem: DispatchWorkItem?
+    private var cachedBattery: BatteryReader.Snapshot?
+    private var cachedBatteryReadAt = Date.distantPast
+    private var batteryFloorLatched = false
+    private let batteryCacheInterval: TimeInterval = 5
+    private let batteryFloorRecoverMargin = 5
+    private let batteryFloorChoices = [10, 15, 20, 30]
     private var pendingInputSourceRecoveryWorkItem: DispatchWorkItem?
     private var globalCapsLockEventMonitor: Any?
     private var localCapsLockEventMonitor: Any?
@@ -309,6 +315,41 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         showMenuBarItem.state = Preferences.showMenuBarIcon ? .on : .off
         menu.addItem(showMenuBarItem)
 
+        let batteryFloorValue = Preferences.batteryFloorEnabled
+            ? "\(Preferences.batteryFloorPercent)%"
+            : strings.batteryFloorOff
+        let batteryFloorItem = NSMenuItem(
+            title: "\(strings.batteryFloorMenu) (\(batteryFloorValue))",
+            action: nil,
+            keyEquivalent: ""
+        )
+        batteryFloorItem.toolTip = strings.batteryFloorDesc
+        let batteryFloorMenu = NSMenu(title: strings.batteryFloorMenu)
+        let batteryFloorOffItem = NSMenuItem(
+            title: strings.batteryFloorOff,
+            action: #selector(selectBatteryFloor),
+            keyEquivalent: ""
+        )
+        batteryFloorOffItem.target = self
+        batteryFloorOffItem.representedObject = "off"
+        batteryFloorOffItem.state = Preferences.batteryFloorEnabled ? .off : .on
+        batteryFloorMenu.addItem(batteryFloorOffItem)
+        for percent in batteryFloorChoices {
+            let item = NSMenuItem(
+                title: "\(percent)%",
+                action: #selector(selectBatteryFloor),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = "\(percent)"
+            item.state = (Preferences.batteryFloorEnabled && Preferences.batteryFloorPercent == percent)
+                ? .on
+                : .off
+            batteryFloorMenu.addItem(item)
+        }
+        menu.setSubmenu(batteryFloorMenu, for: batteryFloorItem)
+        menu.addItem(batteryFloorItem)
+
         let languageItem = NSMenuItem(title: strings.language, action: nil, keyEquivalent: "")
         let languageMenu = NSMenu(title: strings.language)
         for language in AppLanguage.allCases {
@@ -335,6 +376,26 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         menu.addItem(quitItem)
 
         item.menu = menu
+    }
+
+    @objc private func selectBatteryFloor(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String else { return }
+        if rawValue == "off" {
+            setBatteryFloor(enabled: false, percent: nil)
+        } else if let percent = Int(rawValue) {
+            setBatteryFloor(enabled: true, percent: percent)
+        }
+    }
+
+    private func setBatteryFloor(enabled: Bool, percent: Int?) {
+        Preferences.batteryFloorEnabled = enabled
+        if let percent {
+            Preferences.batteryFloorPercent = percent
+        }
+        batteryFloorLatched = false
+        rebuildStatusMenu()
+        applyCurrentCapsLockState(reason: "battery_floor_change")
+        log("preference battery_floor=\(enabled ? "\(Preferences.batteryFloorPercent)%" : "off")")
     }
 
     @objc private func toggleShowMenuBarIcon() {
@@ -560,6 +621,41 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         log("polling_ready interval_ms=250 tolerance_ms=50")
     }
 
+    /// Cached power-source read (refreshed every `batteryCacheInterval`) so the 250ms
+    /// poll never spins IOKit needlessly.
+    private func batterySnapshot() -> BatteryReader.Snapshot? {
+        let now = Date()
+        if let cachedBattery, now.timeIntervalSince(cachedBatteryReadAt) < batteryCacheInterval {
+            return cachedBattery
+        }
+        if let fresh = BatteryReader.read() {
+            cachedBattery = fresh
+            cachedBatteryReadAt = now
+            return fresh
+        }
+        return cachedBattery
+    }
+
+    /// Applies the battery-floor safety override to the Caps Lock intent. On battery at
+    /// or below the floor it releases keep-awake so the Mac can sleep before the battery
+    /// is fully drained; a recover margin keeps it from flapping. Unreadable power state
+    /// stays awake, so the floor can never make things worse than today.
+    private func keepAwakeAfterBatteryFloor(intent: Bool) -> Bool {
+        let battery = batterySnapshot()
+        let result = BatteryFloorPolicy.decide(
+            intent: intent,
+            floorEnabled: Preferences.batteryFloorEnabled,
+            floorPercent: Preferences.batteryFloorPercent,
+            recoverMargin: batteryFloorRecoverMargin,
+            onAC: battery?.onAC ?? false,
+            percent: battery?.percent,
+            batteryReadable: battery != nil,
+            latched: batteryFloorLatched
+        )
+        batteryFloorLatched = result.latched
+        return result.keepAwake
+    }
+
     private func applyCurrentCapsLockState(reason: String) {
         let filterReady = ensureDedicatedCapsLockFilter(
             promptForPermission: false,
@@ -598,7 +694,7 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         }
 
         cancelPendingCapsLockOff()
-        apply(capsLockOn: capsLockOn, reason: reason)
+        apply(capsLockOn: keepAwakeAfterBatteryFloor(intent: capsLockOn), reason: reason)
     }
 
     private func scheduleCapsLockOff(reason: String) {

--- a/Sources/Capsomnia/SystemServices.swift
+++ b/Sources/Capsomnia/SystemServices.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import IOKit
+import IOKit.ps
 
 struct LaunchAgentError: LocalizedError {
     let message: String
@@ -127,5 +128,82 @@ enum ExternalDisplayReader {
 enum DisplaySleepPolicy {
     static func shouldRequestDisplaySleep(externalDisplayConnected: Bool?) -> Bool {
         externalDisplayConnected == false
+    }
+}
+
+/// A point-in-time read of the power source, via IOKit power sources (no subprocess).
+enum BatteryReader {
+    struct Snapshot {
+        /// True when running on wall power (AC / adapter).
+        let onAC: Bool
+        /// Charge percentage 0-100, or nil when no internal battery reading is available.
+        let percent: Int?
+    }
+
+    static func read() -> Snapshot? {
+        guard let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue() else {
+            return nil
+        }
+        guard let sources = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef] else {
+            return nil
+        }
+
+        let providingType = IOPSGetProvidingPowerSourceType(blob)?.takeRetainedValue() as String?
+        let onAC = providingType == kIOPSACPowerValue
+
+        var percent: Int?
+        for source in sources {
+            guard let description = IOPSGetPowerSourceDescription(blob, source)?
+                .takeUnretainedValue() as? [String: Any] else {
+                continue
+            }
+            guard let current = description[kIOPSCurrentCapacityKey as String] as? Int,
+                  let maximum = description[kIOPSMaxCapacityKey as String] as? Int,
+                  maximum > 0 else {
+                continue
+            }
+            percent = Int((Double(current) / Double(maximum) * 100).rounded())
+            break
+        }
+
+        return Snapshot(onAC: onAC, percent: percent)
+    }
+}
+
+/// Pure, deterministic keep-awake decision: user intent with a battery-floor safety
+/// override and hysteresis latch. Extracted from the app delegate so it is unit-testable.
+enum BatteryFloorPolicy {
+    /// - Parameters:
+    ///   - intent: whether the current mode wants the Mac awake.
+    ///   - batteryReadable: false when the power source could not be read at all.
+    ///   - percent: charge 0-100, or nil when unknown (but power source WAS readable).
+    ///   - latched: whether keep-awake is currently released because of a prior low-battery hit.
+    /// - Returns: the keep-awake decision and the next latch state.
+    static func decide(
+        intent: Bool,
+        floorEnabled: Bool,
+        floorPercent: Int,
+        recoverMargin: Int,
+        onAC: Bool,
+        percent: Int?,
+        batteryReadable: Bool,
+        latched: Bool
+    ) -> (keepAwake: Bool, latched: Bool) {
+        guard intent else { return (false, false) }
+        guard floorEnabled else { return (true, false) }
+        guard batteryReadable else { return (true, latched) }
+        if onAC { return (true, false) }
+        guard let percent else { return (true, latched) }
+
+        if latched {
+            if percent >= floorPercent + recoverMargin {
+                return (true, false)
+            }
+            return (false, true)
+        }
+        if percent <= floorPercent {
+            return (false, true)
+        }
+        return (true, false)
     }
 }

--- a/Tests/CapsomniaTests/BatteryFloorPolicyTests.swift
+++ b/Tests/CapsomniaTests/BatteryFloorPolicyTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Capsomnia
+
+final class BatteryFloorPolicyTests: XCTestCase {
+    private func decide(
+        intent: Bool = true,
+        floorEnabled: Bool = true,
+        floor: Int = 15,
+        margin: Int = 5,
+        onAC: Bool = false,
+        percent: Int? = 50,
+        batteryReadable: Bool = true,
+        latched: Bool = false
+    ) -> (keepAwake: Bool, latched: Bool) {
+        BatteryFloorPolicy.decide(
+            intent: intent,
+            floorEnabled: floorEnabled,
+            floorPercent: floor,
+            recoverMargin: margin,
+            onAC: onAC,
+            percent: percent,
+            batteryReadable: batteryReadable,
+            latched: latched
+        )
+    }
+
+    func testNoIntentNeverKeepsAwakeAndClearsLatch() {
+        let result = decide(intent: false, latched: true)
+        XCTAssertFalse(result.keepAwake)
+        XCTAssertFalse(result.latched)
+    }
+
+    func testFloorDisabledKeepsAwakeEvenWhenEmpty() {
+        let result = decide(floorEnabled: false, percent: 3)
+        XCTAssertTrue(result.keepAwake)
+        XCTAssertFalse(result.latched)
+    }
+
+    func testUnreadablePowerStaysAwakeAndPreservesLatch() {
+        let result = decide(percent: nil, batteryReadable: false, latched: true)
+        XCTAssertTrue(result.keepAwake)
+        XCTAssertTrue(result.latched)
+    }
+
+    func testOnACAlwaysKeepsAwakeAndClearsLatch() {
+        let result = decide(onAC: true, percent: 5, latched: true)
+        XCTAssertTrue(result.keepAwake)
+        XCTAssertFalse(result.latched)
+    }
+
+    func testUnknownPercentOnBatteryStaysAwake() {
+        let result = decide(percent: nil)
+        XCTAssertTrue(result.keepAwake)
+    }
+
+    func testAboveFloorKeepsAwake() {
+        let result = decide(percent: 16)
+        XCTAssertTrue(result.keepAwake)
+        XCTAssertFalse(result.latched)
+    }
+
+    func testAtFloorReleasesAndLatches() {
+        let result = decide(percent: 15)
+        XCTAssertFalse(result.keepAwake)
+        XCTAssertTrue(result.latched)
+    }
+
+    func testBelowFloorReleasesAndLatches() {
+        let result = decide(percent: 10)
+        XCTAssertFalse(result.keepAwake)
+        XCTAssertTrue(result.latched)
+    }
+
+    func testHysteresisHoldsBetweenFloorAndRecover() {
+        // latched at 17% (> floor 15 but < recover 20) must stay released -> no oscillation
+        let result = decide(percent: 17, latched: true)
+        XCTAssertFalse(result.keepAwake)
+        XCTAssertTrue(result.latched)
+    }
+
+    func testHysteresisReleasesAtRecoverThreshold() {
+        let result = decide(percent: 20, latched: true)
+        XCTAssertTrue(result.keepAwake)
+        XCTAssertFalse(result.latched)
+    }
+}


### PR DESCRIPTION
## What

Two small, **opt-in** additions. Defaults are unchanged — with no configuration the app behaves exactly as it does today (Caps Lock keeps the Mac awake).

### 1. Keep-awake mode: Off / Caps Lock / Auto
Caps Lock stays the default and works exactly as today. `Auto` keeps the Mac awake automatically, independent of Caps Lock — for the case of closing the lid and driving the machine remotely (e.g. SSH from a phone), where you want it to stay reachable without remembering to toggle a key. `Off` is an explicit no-op.

### 2. Battery floor (opt-in, default 15%)
On battery, keep-awake is released at/below a threshold so the Mac can sleep before the battery fully drains — which, in the remote-use case, would also drop your access. It re-arms on AC, with hysteresis so it doesn't oscillate as the percentage jitters near the threshold.

Implementation notes:
- `BatteryReader` reads the power source via IOKit (`IOPSCopyPowerSourcesInfo`) — no subprocess.
- The decision is isolated in a pure `BatteryFloorPolicy` with **10 unit tests** covering the floor boundary, the hysteresis latch, and the fail-safe cases (unreadable power → stay awake/reachable; on AC → keep; unknown percentage → keep).

Both are surfaced in the status menu (mode items + a Battery floor submenu) and the settings window, following the existing preference + localization patterns.

One small responsiveness change: the poll timer runs in `.default` instead of `.common`, so its periodic `pmset -g` verification never spawns a subprocess while a menu is being tracked.

## Testing
`swift test` — all 24 tests green (14 existing + 10 new).

## Notes
- Fully backwards compatible; nothing changes unless you pick a non-default mode or enable the floor.
- Happy to split this into two PRs (Auto mode / battery floor) if you'd rather review them independently, or to drop/adjust anything that doesn't fit Capsomnia's scope.
