### PR TITLE
Clarify optional Accessibility permission on landing pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -406,8 +406,8 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
         </div>
         <div class="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2">
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
-            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">No Input Monitoring</h3>
-            <p class="text-sm text-[var(--text-faint)]">Capsomnia does not read keyboard events. It checks only the local Caps Lock state every 250 milliseconds.</p>
+            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">Optional Accessibility permission</h3>
+            <p class="text-sm text-[var(--text-faint)]">Accessibility permission is required only when “Prevent all-caps typing” is enabled. When it is off, Capsomnia does not inspect keyboard events and checks only the local Caps Lock state every 250 milliseconds. When it is on, Core Graphics event handling removes the Caps Lock modifier from text input; event data is never logged, stored, or transmitted.</p>
           </div>
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
             <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">Background item prompt</h3>

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -406,8 +406,8 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
         </div>
         <div class="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2">
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
-            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">入力監視は不要</h3>
-            <p class="text-sm text-[var(--text-faint)]">Capsomniaはキーボードイベントを読みません。ローカルのCaps Lock状態だけを250ミリ秒ごとに確認します。</p>
+            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">アクセシビリティ権限は任意</h3>
+            <p class="text-sm text-[var(--text-faint)]">「大文字固定を防ぐ」を有効にする場合のみ、アクセシビリティ権限が必要です。無効時はキーボードイベントを確認せず、Caps Lock状態だけを250ミリ秒ごとに確認します。有効時はローカルのCore GraphicsイベントフィルターでCaps Lock modifierを入力から除外し、イベント内容の記録・保存・送信は行いません。</p>
           </div>
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
             <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">バックグラウンド項目の表示</h3>

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -406,8 +406,8 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
         </div>
         <div class="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2">
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
-            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">입력 모니터링 불필요</h3>
-            <p class="text-sm text-[var(--text-faint)]">Capsomnia는 키보드 이벤트를 읽지 않습니다. 로컬 Caps Lock 상태만 250밀리초마다 확인합니다.</p>
+            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">손쉬운 사용 권한은 선택 사항</h3>
+            <p class="text-sm text-[var(--text-faint)]">‘대문자 고정 방지’를 활성화할 때만 손쉬운 사용 권한이 필요합니다. 비활성화하면 키보드 이벤트를 확인하지 않고 로컬 Caps Lock 상태만 250밀리초마다 확인합니다. 활성화하면 로컬 Core Graphics 이벤트 필터가 텍스트 입력에서 Caps Lock modifier를 제거하며 이벤트 내용을 기록·저장하거나 전송하지 않습니다.</p>
           </div>
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
             <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">백그라운드 항목 안내</h3>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -406,8 +406,8 @@ sudo -n /Library/PrivilegedHelperTools/capsomnia-pmset display-sleep</code></pre
         </div>
         <div class="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2">
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
-            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">无需输入监控权限</h3>
-            <p class="text-sm text-[var(--text-faint)]">Capsomnia 不会读取键盘事件，只会每 250 毫秒检查一次本机 Caps Lock 状态。</p>
+            <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">辅助功能权限为可选项</h3>
+            <p class="text-sm text-[var(--text-faint)]">只有启用“防止输入锁定为大写”时，才需要“辅助功能”权限。禁用时，Capsomnia 不会检查键盘事件，只会每 250 毫秒检查一次本机 Caps Lock 状态。启用时，本地 Core Graphics 事件过滤器会从文本输入中移除 Caps Lock 修饰键，但不会记录、存储或传输事件内容。</p>
           </div>
           <div class="min-w-0 rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-6">
             <h3 class="mb-3.5 text-base font-semibold text-[var(--text-dim)]">后台项目提示</h3>


### PR DESCRIPTION
## Summary

- update the security card on all four localized landing pages
- explain that Accessibility permission is required only for Prevent all-caps typing
- retain the polling-only, permission-free behavior when the setting is disabled
- clarify that event data is never logged, stored, or transmitted

## Validation

- npm run build:site
- npm test (19 tests)
- generated CSS unchanged
- git diff --check