### PR TITLE
Prepare Capsomnia 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 1.1.0 - 2026-07-19
+
 - Add the optional "Prevent all-caps typing" setting. When enabled, the Caps Lock indicator continues to control Capsomnia while normal typing is no longer locked to uppercase. Shift and other modifiers continue to work normally.
+- Add the setting and its Accessibility explanation in English, Japanese, Simplified Chinese, and Korean.
+- Simplify initial setup to the menu bar icon, the optional typing setting, and language while keeping display sleep on lid close and launch at login enabled by default and editable later.
+- Keep menu bar visibility independent from the typing setting while continuing to show a temporary red indicator for errors.
+- Clarify the optional Accessibility behavior on all four localized landing pages.
+- Polish Korean display-sleep and README wording.
 
 ## 1.0.3 - 2026-07-18
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `1.0.3`
+現在のバージョン: `1.1.0`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `1.0.3`
+현재 버전: `1.1.0`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `1.0.3`
+Current version: `1.1.0`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`1.0.3`
+当前版本：`1.1.0`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,12 @@ Before building a release, update:
 - `resources/Info.plist`: `CFBundleVersion`
 - `README.md`: current version
 - `README.ja.md`: current version
+- `README.zh-Hans.md`: current version
+- `README.ko.md`: current version
+- `docs/index.html`: JSON-LD `softwareVersion`
+- `docs/ja/index.html`: JSON-LD `softwareVersion`
+- `docs/zh-hans/index.html`: JSON-LD `softwareVersion`
+- `docs/ko/index.html`: JSON-LD `softwareVersion`
 - `CHANGELOG.md`: release entry
 
 Never replace a published tag or release asset. If a published build needs any change, increment the version and create a new release. Enable GitHub Immutable Releases before publishing the first stable release.

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.3",
+            "softwareVersion": "1.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.3",
+            "softwareVersion": "1.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.3",
+            "softwareVersion": "1.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "1.0.3",
+            "softwareVersion": "1.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>1.0.3</string>
+  <string>1.1.0</string>
 
   <key>CFBundleVersion</key>
-  <string>1.0.3</string>
+  <string>1.1.0</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary

- set the app, README, and localized JSON-LD versions to 1.1.0
- move the Prevent all-caps typing changes into the 1.1.0 changelog entry
- include the post-1.0.3 Korean copy polish and landing-page permission clarification
- complete the release checklist for all four READMEs and localized landing pages

## Validation

- swift build -c release
- swift test (18 tests)
- npm run build:site
- npm test (19 tests)
- generated site CSS unchanged
- SKIP_SIGNING=true ./scripts/build-pkg.sh (1.1.0 payload and ownership validation)
- plutil -lint resources/Info.plist
- zsh -n for release scripts
- git diff --check