### PR TITLE
Redirect legacy English site paths

### DIFF
--- a/Tests/worker-language-router.test.mjs
+++ b/Tests/worker-language-router.test.mjs
@@ -167,6 +167,30 @@ test("explicit Korean choice sets a Korean cookie and cleans the URL", async () 
   assert.equal(origin.requests.length, 0);
 });
 
+test("legacy English paths redirect permanently and remember English", async () => {
+  for (const path of ["/en", "/en/"]) {
+    const origin = originRecorder();
+    const response = await handleRequest(
+      new Request(`https://capsomnia.com${path}?utm_source=legacy`, {
+        headers: { "Accept-Language": "ja-JP" }
+      }),
+      origin.fetch
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+      response.headers.get("Location"),
+      "https://capsomnia.com/?utm_source=legacy"
+    );
+    assert.equal(response.headers.get("Cache-Control"), "private, no-store");
+    assert.match(
+      response.headers.get("Set-Cookie"),
+      /^capsomnia_locale=en; Path=\/; Max-Age=31536000; HttpOnly; Secure; SameSite=Lax$/
+    );
+    assert.equal(origin.requests.length, 0);
+  }
+});
+
 test("localized paths and non-navigation methods pass through", async () => {
   const localizedOrigin = originRecorder();
   const localizedResponse = await handleRequest(

--- a/worker/index.mjs
+++ b/worker/index.mjs
@@ -114,6 +114,20 @@ function redirectToLocale(sourceUrl, locale, rememberChoice = false) {
   });
 }
 
+function redirectLegacyEnglishPath(sourceUrl) {
+  const destination = new URL(sourceUrl);
+  destination.pathname = "/";
+
+  return new Response(null, {
+    status: 301,
+    headers: {
+      "Cache-Control": "private, no-store",
+      Location: destination.toString(),
+      "Set-Cookie": languageCookie("en")
+    }
+  });
+}
+
 async function fetchRootWithVary(request, fetchOrigin) {
   const response = await fetchOrigin(request);
   const headers = new Headers(response.headers);
@@ -136,6 +150,10 @@ export async function handleRequest(request, fetchOrigin = fetch) {
 
   if (requestedLocale) {
     return redirectToLocale(url, requestedLocale, true);
+  }
+
+  if (url.pathname === "/en" || url.pathname === "/en/") {
+    return redirectLegacyEnglishPath(url);
   }
 
   if (url.pathname !== "/") {


### PR DESCRIPTION
## Summary

- permanently redirect legacy /en and /en/ paths to the canonical English root
- preserve query parameters and remember English for visitors following old links
- add Worker coverage for both legacy path variants

## Verification

- npm test
- npm run deploy:worker -- --dry-run