### PR TITLE
Release Capsomnia 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 2.0.1 - 2026-07-24
+
+- Cancel shortcut recording when Settings closes so reopening Capsomnia cannot preserve a stale “Press keys…” state or leave the saved global shortcut suspended.
+- Add an explicit localized Clear button while editing an assigned shortcut, with language-independent padding that matches the adjacent Esc action.
+- Keep Delete and Forward Delete as keyboard alternatives for clearing an assigned shortcut.
+
 ## 2.0.0 - 2026-07-21
 
 - Add reliable Caps Lock toggling from the menu bar by using the real IOHID modifier-lock state as the single source of truth for the physical LED, menu bar status, and sleep prevention.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `2.0.0`
+現在のバージョン: `2.0.1`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `2.0.0`
+현재 버전: `2.0.1`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `2.0.0`
+Current version: `2.0.1`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`2.0.0`
+当前版本：`2.0.1`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -97,6 +97,7 @@ struct AppStrings {
     let shortcutRecorderPlaceholder: String
     let shortcutRecorderRecording: String
     let shortcutRecorderAction: String
+    let shortcutRecorderClear: String
     let shortcutRegistrationFailed: String
     let openCapsomnia: String
     let quit: String
@@ -141,6 +142,7 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "Not Set",
                 shortcutRecorderRecording: "Press keys…",
                 shortcutRecorderAction: "Record",
+                shortcutRecorderClear: "Clear",
                 shortcutRegistrationFailed: "That shortcut is unavailable",
                 openCapsomnia: "Open Capsomnia",
                 quit: "Quit",
@@ -179,6 +181,7 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "미설정",
                 shortcutRecorderRecording: "입력 대기…",
                 shortcutRecorderAction: "입력",
+                shortcutRecorderClear: "삭제",
                 shortcutRegistrationFailed: "사용할 수 없는 단축키입니다",
                 openCapsomnia: "Capsomnia 열기",
                 quit: "종료",
@@ -217,6 +220,7 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "未設定",
                 shortcutRecorderRecording: "入力待ち…",
                 shortcutRecorderAction: "入力する",
+                shortcutRecorderClear: "削除",
                 shortcutRegistrationFailed: "そのショートカットは使用できません",
                 openCapsomnia: "Capsomniaを開く",
                 quit: "終了",
@@ -255,6 +259,7 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "未设置",
                 shortcutRecorderRecording: "等待输入…",
                 shortcutRecorderAction: "录入",
+                shortcutRecorderClear: "删除",
                 shortcutRegistrationFailed: "该快捷键不可用",
                 openCapsomnia: "打开 Capsomnia",
                 quit: "退出",

--- a/Sources/Capsomnia/BrandedControls.swift
+++ b/Sources/Capsomnia/BrandedControls.swift
@@ -314,11 +314,82 @@ final class DisclosureButton: NSView {
     }
 }
 
+private final class PaddedPillButton: NSButton {
+    private let pillLabel = NSTextField(labelWithString: "")
+    private let horizontalPadding: CGFloat
+    private let verticalPadding: CGFloat
+
+    init(horizontalPadding: CGFloat, verticalPadding: CGFloat) {
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+        super.init(frame: .zero)
+
+        isBordered = false
+        title = ""
+        pillLabel.translatesAutoresizingMaskIntoConstraints = false
+        pillLabel.setAccessibilityElement(false)
+        addSubview(pillLabel)
+
+        NSLayoutConstraint.activate([
+            pillLabel.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: horizontalPadding
+            ),
+            pillLabel.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -horizontalPadding
+            ),
+            pillLabel.topAnchor.constraint(
+                equalTo: topAnchor,
+                constant: verticalPadding
+            ),
+            pillLabel.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -verticalPadding
+            )
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override var intrinsicContentSize: NSSize {
+        let labelSize = pillLabel.intrinsicContentSize
+        return NSSize(
+            width: ceil(labelSize.width) + horizontalPadding * 2,
+            height: ceil(labelSize.height) + verticalPadding * 2
+        )
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isHidden, alphaValue > 0, bounds.contains(point) else {
+            return nil
+        }
+        return self
+    }
+
+    func setPillTitle(_ title: String) {
+        pillLabel.stringValue = title
+        toolTip = title
+        setAccessibilityLabel(title)
+        invalidateIntrinsicContentSize()
+    }
+
+    func setPillFont(_ font: NSFont) {
+        pillLabel.font = font
+        invalidateIntrinsicContentSize()
+    }
+
+    func setPillColor(_ color: NSColor) {
+        pillLabel.textColor = color
+    }
+}
+
 /// A keycap-style recorder for Capsomnia's persisted global shortcut.
 final class ShortcutRecorderButton: NSView {
     private var placeholderTitle: String
     private var recordingTitle: String
     private var actionTitle: String
+    private var clearTitle: String
     private var registrationFailedTitle: String
     private var shortcut: KeyboardShortcut?
     private var isRecording = false
@@ -336,16 +407,22 @@ final class ShortcutRecorderButton: NSView {
     private let keycapStack = NSStackView()
     private let actionPill = NSView()
     private let actionLabel = NSTextField(labelWithString: "")
+    private let clearButton = PaddedPillButton(
+        horizontalPadding: 11,
+        verticalPadding: 7
+    )
 
     init(
         placeholder: String,
         recording: String,
         action: String,
+        clear: String,
         registrationFailed: String
     ) {
         placeholderTitle = placeholder
         recordingTitle = recording
         actionTitle = action
+        clearTitle = clear
         registrationFailedTitle = registrationFailed
         super.init(frame: .zero)
 
@@ -411,11 +488,25 @@ final class ShortcutRecorderButton: NSView {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         actionPill.addSubview(actionLabel)
 
+        clearButton.isBordered = false
+        clearButton.setPillFont(.systemFont(ofSize: 11, weight: .semibold))
+        clearButton.setPillColor(.systemRed)
+        clearButton.focusRingType = .exterior
+        clearButton.target = self
+        clearButton.action = #selector(clearRecordedShortcut)
+        clearButton.translatesAutoresizingMaskIntoConstraints = false
+        clearButton.wantsLayer = true
+        clearButton.layer?.cornerRadius = 8
+        clearButton.layer?.backgroundColor = NSColor.systemRed.withAlphaComponent(0.1).cgColor
+        clearButton.layer?.borderWidth = 1
+        clearButton.layer?.borderColor = NSColor.systemRed.withAlphaComponent(0.28).cgColor
+
         let content = NSStackView(views: [
             iconHolder,
             valueLabel,
             flexibleSpace,
             keycapStack,
+            clearButton,
             actionPill
         ])
         content.orientation = .horizontal
@@ -463,11 +554,13 @@ final class ShortcutRecorderButton: NSView {
         placeholder: String,
         recording: String,
         action: String,
+        clear: String,
         registrationFailed: String
     ) {
         placeholderTitle = placeholder
         recordingTitle = recording
         actionTitle = action
+        clearTitle = clear
         registrationFailedTitle = registrationFailed
         refreshAppearance()
     }
@@ -475,6 +568,12 @@ final class ShortcutRecorderButton: NSView {
     func setShortcut(_ shortcut: KeyboardShortcut?) {
         self.shortcut = shortcut
         isShowingRegistrationError = false
+        refreshAppearance()
+    }
+
+    func cancelRecording() {
+        guard isRecording else { return }
+        endRecording()
         refreshAppearance()
     }
 
@@ -553,10 +652,7 @@ final class ShortcutRecorderButton: NSView {
 
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
-        if isRecording {
-            endRecording()
-            refreshAppearance()
-        }
+        cancelRecording()
         needsDisplay = true
         return result
     }
@@ -585,6 +681,11 @@ final class ShortcutRecorderButton: NSView {
         refreshAppearance()
     }
 
+    @objc private func clearRecordedShortcut() {
+        guard isRecording, shortcut != nil else { return }
+        commit(nil)
+    }
+
     private func refreshAppearance() {
         valueLabel.stringValue = isShowingRegistrationError
             ? registrationFailedTitle
@@ -593,6 +694,7 @@ final class ShortcutRecorderButton: NSView {
             ? .systemRed
             : isRecording ? Brand.led : Brand.textDim
         actionLabel.stringValue = isRecording ? "Esc" : actionTitle
+        clearButton.setPillTitle(clearTitle)
 
         let tokens = shortcut?.displayTokens ?? []
         let hasRecordedShortcut = !tokens.isEmpty
@@ -601,6 +703,7 @@ final class ShortcutRecorderButton: NSView {
         valueLabel.isHidden = hasRecordedShortcut
         keycapStack.isHidden = !hasRecordedShortcut
         actionPill.isHidden = hasRecordedShortcut
+        clearButton.isHidden = !(isRecording && shortcut != nil)
 
         if hasRecordedShortcut, tokens != renderedKeycapTokens {
             renderedKeycapTokens = tokens

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -72,6 +72,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         placeholder: "",
         recording: "",
         action: "",
+        clear: "",
         registrationFailed: ""
     )
 
@@ -192,6 +193,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             placeholder: strings.shortcutRecorderPlaceholder,
             recording: strings.shortcutRecorderRecording,
             action: strings.shortcutRecorderAction,
+            clear: strings.shortcutRecorderClear,
             registrationFailed: strings.shortcutRegistrationFailed
         )
         shortcutRecorder.setAccessibilityLabel(strings.keyboardShortcut)
@@ -219,6 +221,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
+        // The controller and window are reused after closing, so transient
+        // recording state must not survive into the next presentation.
+        shortcutRecorder.cancelRecording()
         guard page == .initialPreferences else { return }
         finishInitialSetup()
     }

--- a/Tests/CapsomniaTests/GlobalHotKeyTests.swift
+++ b/Tests/CapsomniaTests/GlobalHotKeyTests.swift
@@ -154,6 +154,7 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
+            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         var changes: [KeyboardShortcut?] = []
@@ -189,6 +190,92 @@ final class GlobalHotKeyTests: XCTestCase {
     }
 
     @MainActor
+    func testRecorderCancelEndsRecordingWithoutChangingShortcut() {
+        _ = NSApplication.shared
+        let shortcut = KeyboardShortcut(
+            keyCode: UInt32(kVK_ANSI_C),
+            modifiers: [.command],
+            key: "C"
+        )
+        let recorder = ShortcutRecorderButton(
+            placeholder: "Not Set",
+            recording: "Press keys…",
+            action: "Record",
+            clear: "Clear",
+            registrationFailed: "Unavailable"
+        )
+        recorder.setShortcut(shortcut)
+        var changes: [KeyboardShortcut?] = []
+        var recordingStates: [Bool] = []
+        recorder.onShortcutChange = {
+            changes.append($0)
+            return true
+        }
+        recorder.onRecordingChange = { recordingStates.append($0) }
+
+        XCTAssertTrue(recorder.accessibilityPerformPress())
+        XCTAssertEqual(recorder.title, "Press keys…")
+
+        recorder.cancelRecording()
+
+        XCTAssertEqual(recorder.title, shortcut.displayValue)
+        XCTAssertTrue(changes.isEmpty)
+        XCTAssertEqual(recordingStates, [true, false])
+    }
+
+    @MainActor
+    func testRecorderShowsClearButtonWhileEditingRecordedShortcut() throws {
+        _ = NSApplication.shared
+        let shortcut = KeyboardShortcut(
+            keyCode: UInt32(kVK_ANSI_C),
+            modifiers: [.command],
+            key: "C"
+        )
+        let recorder = ShortcutRecorderButton(
+            placeholder: "Not Set",
+            recording: "Press keys…",
+            action: "Record",
+            clear: "Clear",
+            registrationFailed: "Unavailable"
+        )
+        recorder.setShortcut(shortcut)
+        var changes: [KeyboardShortcut?] = []
+        var recordingStates: [Bool] = []
+        recorder.onShortcutChange = {
+            changes.append($0)
+            return true
+        }
+        recorder.onRecordingChange = { recordingStates.append($0) }
+        let clearButton: NSButton = try XCTUnwrap(
+            descendants(of: recorder).first {
+                $0.accessibilityLabel() == "Clear"
+            }
+        )
+        XCTAssertTrue(clearButton.isHidden)
+
+        XCTAssertTrue(recorder.accessibilityPerformPress())
+
+        XCTAssertFalse(clearButton.isHidden)
+        clearButton.frame = NSRect(
+            origin: .zero,
+            size: clearButton.intrinsicContentSize
+        )
+        XCTAssertTrue(
+            clearButton.hitTest(
+                NSPoint(
+                    x: clearButton.bounds.midX,
+                    y: clearButton.bounds.midY
+                )
+            ) === clearButton
+        )
+        clearButton.performClick(nil)
+        XCTAssertEqual(recorder.title, "Not Set")
+        XCTAssertNil(changes.last!)
+        XCTAssertEqual(recordingStates, [true, false])
+        XCTAssertTrue(clearButton.isHidden)
+    }
+
+    @MainActor
     func testRecorderKeepsPreviousShortcutWhenRegistrationFails() throws {
         _ = NSApplication.shared
         let previous = KeyboardShortcut(
@@ -200,6 +287,7 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
+            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         recorder.setShortcut(previous)
@@ -267,5 +355,12 @@ final class GlobalHotKeyTests: XCTestCase {
             isARepeat: false,
             keyCode: 51
         )
+    }
+
+    private func descendants<T: NSView>(of view: NSView) -> [T] {
+        view.subviews.flatMap { child -> [T] in
+            let current = (child as? T).map { [$0] } ?? []
+            return current + descendants(of: child)
+        }
     }
 }

--- a/Tests/CapsomniaTests/LocalizationTests.swift
+++ b/Tests/CapsomniaTests/LocalizationTests.swift
@@ -36,6 +36,7 @@ final class LocalizationTests: XCTestCase {
             XCTAssertFalse(strings.shortcutRecorderPlaceholder.isEmpty)
             XCTAssertFalse(strings.shortcutRecorderRecording.isEmpty)
             XCTAssertFalse(strings.shortcutRecorderAction.isEmpty)
+            XCTAssertFalse(strings.shortcutRecorderClear.isEmpty)
             XCTAssertFalse(strings.shortcutRegistrationFailed.isEmpty)
             XCTAssertFalse(strings.initialPreferencesHeading.isEmpty)
             XCTAssertFalse(strings.done.isEmpty)

--- a/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
+++ b/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
@@ -186,7 +186,30 @@ final class SettingsWindowControllerTests: XCTestCase {
         )
     }
 
-    private func makeController() -> SettingsWindowController {
+    func testClosingWindowCancelsShortcutRecording() throws {
+        _ = NSApplication.shared
+        var recordingStates: [Bool] = []
+        let controller = makeController(
+            onKeyboardShortcutRecordingChange: {
+                recordingStates.append($0)
+            }
+        )
+
+        controller.show(page: .advancedSettings)
+        let contentView = try XCTUnwrap(controller.window?.contentView)
+        let recorder: ShortcutRecorderButton = try XCTUnwrap(
+            visibleDescendants(of: contentView).first
+        )
+        XCTAssertTrue(recorder.accessibilityPerformPress())
+
+        controller.close()
+
+        XCTAssertEqual(recordingStates, [true, false])
+    }
+
+    private func makeController(
+        onKeyboardShortcutRecordingChange: @escaping (Bool) -> Void = { _ in }
+    ) -> SettingsWindowController {
         SettingsWindowController(
             onDedicatedCapsLockModeChange: { _ in },
             onShowMenuBarIconChange: { _ in },
@@ -194,7 +217,7 @@ final class SettingsWindowControllerTests: XCTestCase {
             onLaunchAtLoginChange: { _ in },
             onDisplaySleepOnLidCloseChange: { _ in },
             onKeyboardShortcutChange: { _ in true },
-            onKeyboardShortcutRecordingChange: { _ in },
+            onKeyboardShortcutRecordingChange: onKeyboardShortcutRecordingChange,
             onFinishInitialSetup: {}
         )
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.0",
+            "softwareVersion": "2.0.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.0",
+            "softwareVersion": "2.0.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.0",
+            "softwareVersion": "2.0.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,7 +7,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -18,7 +18,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -29,7 +29,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -40,7 +40,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.0",
+            "softwareVersion": "2.0.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>2.0.0</string>
+  <string>2.0.1</string>
 
   <key>CFBundleVersion</key>
-  <string>2.0.0</string>
+  <string>2.0.1</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary
- cancel shortcut recording when Settings closes so the saved shortcut is restored
- add a localized Clear button while editing an assigned shortcut
- size Clear from its localized text with the same padding as Esc
- update app, README, site metadata, sitemap, and changelog to 2.0.1

## Validation
- `swift test` (41 tests passed; 2 hardware-only tests skipped)
- warnings-as-errors release build
- unsigned package payload verification
- `npm run build:site` and `npm test` (20 tests passed)
- shell syntax checks