### PR TITLE
Release Capsomnia 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 2.0.2 - 2026-07-24
+
+- Replace the nonfunctional clickable Clear control with concise Del and Esc keyboard hints while editing an assigned shortcut.
+- Keep both the Mac Delete key and Forward Delete available for clearing the shortcut, while Esc cancels without changing it.
+
 ## 2.0.1 - 2026-07-24
 
 - Cancel shortcut recording when Settings closes so reopening Capsomnia cannot preserve a stale “Press keys…” state or leave the saved global shortcut suspended.

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `2.0.1`
+現在のバージョン: `2.0.2`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `2.0.1`
+현재 버전: `2.0.2`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `2.0.1`
+Current version: `2.0.2`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -16,7 +16,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`2.0.1`
+当前版本：`2.0.2`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -97,7 +97,6 @@ struct AppStrings {
     let shortcutRecorderPlaceholder: String
     let shortcutRecorderRecording: String
     let shortcutRecorderAction: String
-    let shortcutRecorderClear: String
     let shortcutRegistrationFailed: String
     let openCapsomnia: String
     let quit: String
@@ -142,7 +141,6 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "Not Set",
                 shortcutRecorderRecording: "Press keys…",
                 shortcutRecorderAction: "Record",
-                shortcutRecorderClear: "Clear",
                 shortcutRegistrationFailed: "That shortcut is unavailable",
                 openCapsomnia: "Open Capsomnia",
                 quit: "Quit",
@@ -181,7 +179,6 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "미설정",
                 shortcutRecorderRecording: "입력 대기…",
                 shortcutRecorderAction: "입력",
-                shortcutRecorderClear: "삭제",
                 shortcutRegistrationFailed: "사용할 수 없는 단축키입니다",
                 openCapsomnia: "Capsomnia 열기",
                 quit: "종료",
@@ -220,7 +217,6 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "未設定",
                 shortcutRecorderRecording: "入力待ち…",
                 shortcutRecorderAction: "入力する",
-                shortcutRecorderClear: "削除",
                 shortcutRegistrationFailed: "そのショートカットは使用できません",
                 openCapsomnia: "Capsomniaを開く",
                 quit: "終了",
@@ -259,7 +255,6 @@ struct AppStrings {
                 shortcutRecorderPlaceholder: "未设置",
                 shortcutRecorderRecording: "等待输入…",
                 shortcutRecorderAction: "录入",
-                shortcutRecorderClear: "删除",
                 shortcutRegistrationFailed: "该快捷键不可用",
                 openCapsomnia: "打开 Capsomnia",
                 quit: "退出",

--- a/Sources/Capsomnia/BrandedControls.swift
+++ b/Sources/Capsomnia/BrandedControls.swift
@@ -314,82 +314,11 @@ final class DisclosureButton: NSView {
     }
 }
 
-private final class PaddedPillButton: NSButton {
-    private let pillLabel = NSTextField(labelWithString: "")
-    private let horizontalPadding: CGFloat
-    private let verticalPadding: CGFloat
-
-    init(horizontalPadding: CGFloat, verticalPadding: CGFloat) {
-        self.horizontalPadding = horizontalPadding
-        self.verticalPadding = verticalPadding
-        super.init(frame: .zero)
-
-        isBordered = false
-        title = ""
-        pillLabel.translatesAutoresizingMaskIntoConstraints = false
-        pillLabel.setAccessibilityElement(false)
-        addSubview(pillLabel)
-
-        NSLayoutConstraint.activate([
-            pillLabel.leadingAnchor.constraint(
-                equalTo: leadingAnchor,
-                constant: horizontalPadding
-            ),
-            pillLabel.trailingAnchor.constraint(
-                equalTo: trailingAnchor,
-                constant: -horizontalPadding
-            ),
-            pillLabel.topAnchor.constraint(
-                equalTo: topAnchor,
-                constant: verticalPadding
-            ),
-            pillLabel.bottomAnchor.constraint(
-                equalTo: bottomAnchor,
-                constant: -verticalPadding
-            )
-        ])
-    }
-
-    required init?(coder: NSCoder) { nil }
-
-    override var intrinsicContentSize: NSSize {
-        let labelSize = pillLabel.intrinsicContentSize
-        return NSSize(
-            width: ceil(labelSize.width) + horizontalPadding * 2,
-            height: ceil(labelSize.height) + verticalPadding * 2
-        )
-    }
-
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        guard !isHidden, alphaValue > 0, bounds.contains(point) else {
-            return nil
-        }
-        return self
-    }
-
-    func setPillTitle(_ title: String) {
-        pillLabel.stringValue = title
-        toolTip = title
-        setAccessibilityLabel(title)
-        invalidateIntrinsicContentSize()
-    }
-
-    func setPillFont(_ font: NSFont) {
-        pillLabel.font = font
-        invalidateIntrinsicContentSize()
-    }
-
-    func setPillColor(_ color: NSColor) {
-        pillLabel.textColor = color
-    }
-}
-
 /// A keycap-style recorder for Capsomnia's persisted global shortcut.
 final class ShortcutRecorderButton: NSView {
     private var placeholderTitle: String
     private var recordingTitle: String
     private var actionTitle: String
-    private var clearTitle: String
     private var registrationFailedTitle: String
     private var shortcut: KeyboardShortcut?
     private var isRecording = false
@@ -405,24 +334,20 @@ final class ShortcutRecorderButton: NSView {
     private let valueLabel = NSTextField(labelWithString: "")
     private let flexibleSpace = NSView()
     private let keycapStack = NSStackView()
+    private let deletePill = NSView()
+    private let deleteLabel = NSTextField(labelWithString: "Del")
     private let actionPill = NSView()
     private let actionLabel = NSTextField(labelWithString: "")
-    private let clearButton = PaddedPillButton(
-        horizontalPadding: 11,
-        verticalPadding: 7
-    )
 
     init(
         placeholder: String,
         recording: String,
         action: String,
-        clear: String,
         registrationFailed: String
     ) {
         placeholderTitle = placeholder
         recordingTitle = recording
         actionTitle = action
-        clearTitle = clear
         registrationFailedTitle = registrationFailed
         super.init(frame: .zero)
 
@@ -488,25 +413,25 @@ final class ShortcutRecorderButton: NSView {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         actionPill.addSubview(actionLabel)
 
-        clearButton.isBordered = false
-        clearButton.setPillFont(.systemFont(ofSize: 11, weight: .semibold))
-        clearButton.setPillColor(.systemRed)
-        clearButton.focusRingType = .exterior
-        clearButton.target = self
-        clearButton.action = #selector(clearRecordedShortcut)
-        clearButton.translatesAutoresizingMaskIntoConstraints = false
-        clearButton.wantsLayer = true
-        clearButton.layer?.cornerRadius = 8
-        clearButton.layer?.backgroundColor = NSColor.systemRed.withAlphaComponent(0.1).cgColor
-        clearButton.layer?.borderWidth = 1
-        clearButton.layer?.borderColor = NSColor.systemRed.withAlphaComponent(0.28).cgColor
+        deletePill.translatesAutoresizingMaskIntoConstraints = false
+        deletePill.wantsLayer = true
+        deletePill.layer?.cornerRadius = 8
+        deletePill.layer?.backgroundColor = NSColor.systemRed.withAlphaComponent(0.1).cgColor
+        deletePill.layer?.borderWidth = 1
+        deletePill.layer?.borderColor = NSColor.systemRed.withAlphaComponent(0.28).cgColor
+
+        deleteLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        deleteLabel.textColor = .systemRed
+        deleteLabel.alignment = .center
+        deleteLabel.translatesAutoresizingMaskIntoConstraints = false
+        deletePill.addSubview(deleteLabel)
 
         let content = NSStackView(views: [
             iconHolder,
             valueLabel,
             flexibleSpace,
             keycapStack,
-            clearButton,
+            deletePill,
             actionPill
         ])
         content.orientation = .horizontal
@@ -526,6 +451,10 @@ final class ShortcutRecorderButton: NSView {
             actionLabel.trailingAnchor.constraint(equalTo: actionPill.trailingAnchor, constant: -11),
             actionLabel.topAnchor.constraint(equalTo: actionPill.topAnchor, constant: 7),
             actionLabel.bottomAnchor.constraint(equalTo: actionPill.bottomAnchor, constant: -7),
+            deleteLabel.leadingAnchor.constraint(equalTo: deletePill.leadingAnchor, constant: 11),
+            deleteLabel.trailingAnchor.constraint(equalTo: deletePill.trailingAnchor, constant: -11),
+            deleteLabel.topAnchor.constraint(equalTo: deletePill.topAnchor, constant: 7),
+            deleteLabel.bottomAnchor.constraint(equalTo: deletePill.bottomAnchor, constant: -7),
             content.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 13),
             content.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -13),
             content.topAnchor.constraint(equalTo: topAnchor, constant: 12),
@@ -554,13 +483,11 @@ final class ShortcutRecorderButton: NSView {
         placeholder: String,
         recording: String,
         action: String,
-        clear: String,
         registrationFailed: String
     ) {
         placeholderTitle = placeholder
         recordingTitle = recording
         actionTitle = action
-        clearTitle = clear
         registrationFailedTitle = registrationFailed
         refreshAppearance()
     }
@@ -681,11 +608,6 @@ final class ShortcutRecorderButton: NSView {
         refreshAppearance()
     }
 
-    @objc private func clearRecordedShortcut() {
-        guard isRecording, shortcut != nil else { return }
-        commit(nil)
-    }
-
     private func refreshAppearance() {
         valueLabel.stringValue = isShowingRegistrationError
             ? registrationFailedTitle
@@ -694,7 +616,6 @@ final class ShortcutRecorderButton: NSView {
             ? .systemRed
             : isRecording ? Brand.led : Brand.textDim
         actionLabel.stringValue = isRecording ? "Esc" : actionTitle
-        clearButton.setPillTitle(clearTitle)
 
         let tokens = shortcut?.displayTokens ?? []
         let hasRecordedShortcut = !tokens.isEmpty
@@ -703,7 +624,7 @@ final class ShortcutRecorderButton: NSView {
         valueLabel.isHidden = hasRecordedShortcut
         keycapStack.isHidden = !hasRecordedShortcut
         actionPill.isHidden = hasRecordedShortcut
-        clearButton.isHidden = !(isRecording && shortcut != nil)
+        deletePill.isHidden = !(isRecording && shortcut != nil)
 
         if hasRecordedShortcut, tokens != renderedKeycapTokens {
             renderedKeycapTokens = tokens

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -72,7 +72,6 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         placeholder: "",
         recording: "",
         action: "",
-        clear: "",
         registrationFailed: ""
     )
 
@@ -193,7 +192,6 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             placeholder: strings.shortcutRecorderPlaceholder,
             recording: strings.shortcutRecorderRecording,
             action: strings.shortcutRecorderAction,
-            clear: strings.shortcutRecorderClear,
             registrationFailed: strings.shortcutRegistrationFailed
         )
         shortcutRecorder.setAccessibilityLabel(strings.keyboardShortcut)

--- a/Tests/CapsomniaTests/GlobalHotKeyTests.swift
+++ b/Tests/CapsomniaTests/GlobalHotKeyTests.swift
@@ -154,7 +154,6 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
-            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         var changes: [KeyboardShortcut?] = []
@@ -201,7 +200,6 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
-            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         recorder.setShortcut(shortcut)
@@ -224,7 +222,7 @@ final class GlobalHotKeyTests: XCTestCase {
     }
 
     @MainActor
-    func testRecorderShowsClearButtonWhileEditingRecordedShortcut() throws {
+    func testRecorderShowsDeleteHintWhileEditingRecordedShortcut() throws {
         _ = NSApplication.shared
         let shortcut = KeyboardShortcut(
             keyCode: UInt32(kVK_ANSI_C),
@@ -235,7 +233,6 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
-            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         recorder.setShortcut(shortcut)
@@ -246,33 +243,21 @@ final class GlobalHotKeyTests: XCTestCase {
             return true
         }
         recorder.onRecordingChange = { recordingStates.append($0) }
-        let clearButton: NSButton = try XCTUnwrap(
+        let deleteLabel: NSTextField = try XCTUnwrap(
             descendants(of: recorder).first {
-                $0.accessibilityLabel() == "Clear"
+                $0.stringValue == "Del"
             }
         )
-        XCTAssertTrue(clearButton.isHidden)
+        XCTAssertTrue(deleteLabel.superview?.isHidden == true)
 
         XCTAssertTrue(recorder.accessibilityPerformPress())
 
-        XCTAssertFalse(clearButton.isHidden)
-        clearButton.frame = NSRect(
-            origin: .zero,
-            size: clearButton.intrinsicContentSize
-        )
-        XCTAssertTrue(
-            clearButton.hitTest(
-                NSPoint(
-                    x: clearButton.bounds.midX,
-                    y: clearButton.bounds.midY
-                )
-            ) === clearButton
-        )
-        clearButton.performClick(nil)
+        XCTAssertFalse(deleteLabel.superview?.isHidden == true)
+        recorder.keyDown(with: try XCTUnwrap(makeDeleteEvent()))
         XCTAssertEqual(recorder.title, "Not Set")
         XCTAssertNil(changes.last!)
         XCTAssertEqual(recordingStates, [true, false])
-        XCTAssertTrue(clearButton.isHidden)
+        XCTAssertTrue(deleteLabel.superview?.isHidden == true)
     }
 
     @MainActor
@@ -287,7 +272,6 @@ final class GlobalHotKeyTests: XCTestCase {
             placeholder: "Not Set",
             recording: "Press keys…",
             action: "Record",
-            clear: "Clear",
             registrationFailed: "Unavailable"
         )
         recorder.setShortcut(previous)

--- a/Tests/CapsomniaTests/LocalizationTests.swift
+++ b/Tests/CapsomniaTests/LocalizationTests.swift
@@ -36,7 +36,6 @@ final class LocalizationTests: XCTestCase {
             XCTAssertFalse(strings.shortcutRecorderPlaceholder.isEmpty)
             XCTAssertFalse(strings.shortcutRecorderRecording.isEmpty)
             XCTAssertFalse(strings.shortcutRecorderAction.isEmpty)
-            XCTAssertFalse(strings.shortcutRecorderClear.isEmpty)
             XCTAssertFalse(strings.shortcutRegistrationFailed.isEmpty)
             XCTAssertFalse(strings.initialPreferencesHeading.isEmpty)
             XCTAssertFalse(strings.done.isEmpty)

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.1",
+            "softwareVersion": "2.0.2",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.1",
+            "softwareVersion": "2.0.2",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.1",
+            "softwareVersion": "2.0.2",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.1",
+            "softwareVersion": "2.0.2",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>2.0.1</string>
+  <string>2.0.2</string>
 
   <key>CFBundleVersion</key>
-  <string>2.0.1</string>
+  <string>2.0.2</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Summary
- replace the nonfunctional clickable Clear control with passive `Del` and `Esc` keyboard hints
- keep Mac Delete and Forward Delete for clearing, and Esc for cancelling
- remove the unused localized Clear strings and custom button implementation
- update app, README, site metadata, and changelog to 2.0.2

## Validation
- `swift test` (41 tests passed; 2 hardware-only tests skipped)
- warnings-as-errors release build
- unsigned package payload verification
- `npm run build:site` and `npm test` (20 tests passed)
- shell syntax checks
- local app UI confirmed by the maintainer