### PR TITLE
Release Capsomnia 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 2.0.3 - 2026-07-27
+
+- Preserve sleep prevention when macOS clears Caps Lock while switching from an IME to a keyboard layout such as ABC or U.S.
+- Re-assert Caps Lock after selected input source changes while honoring intentional physical-key, menu, and registered-shortcut toggles.
+- Coalesce input-source notifications and tolerate transient HID readback delays during Caps Lock recovery.
+
 ## 2.0.2 - 2026-07-24
 
 - Replace the nonfunctional clickable Clear control with concise Del and Esc keyboard hints while editing an assigned shortcut.

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `2.0.2`
+現在のバージョン: `2.0.3`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `2.0.2`
+현재 버전: `2.0.3`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `2.0.2`
+Current version: `2.0.3`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`2.0.2`
+当前版本：`2.0.3`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.2",
+            "softwareVersion": "2.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.2",
+            "softwareVersion": "2.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.2",
+            "softwareVersion": "2.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,7 +7,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -18,7 +18,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -29,7 +29,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -40,7 +40,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "2.0.2",
+            "softwareVersion": "2.0.3",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>2.0.2</string>
+  <string>2.0.3</string>
 
   <key>CFBundleVersion</key>
-  <string>2.0.2</string>
+  <string>2.0.3</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>


### PR DESCRIPTION
## Release 2.0.3

- Preserve sleep prevention when macOS clears Caps Lock while switching from an IME to a keyboard layout such as ABC or U.S.
- Re-assert Caps Lock after selected input source changes while honoring intentional physical-key, menu, and registered-shortcut toggles.
- Coalesce input-source notifications and tolerate transient HID readback delays during recovery.
- Update localized README, landing-page metadata, sitemap dates, and CHANGELOG to 2.0.3.

## Verification

- `swift test`: 41 passed, 2 hardware-only skipped
- `npm test`: 20 passed
- `npm run build:site`: passed
- Generated CSS has no drift