### PR TITLE
Fix landing page stylesheet cache busting

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="/styles.css?v=20260725-responsive-meta" />
+    <link rel="stylesheet" href="/styles.css?v=20260801-github-header" />
   </head>
   <body class="bg-[var(--bg)] text-[var(--text)] antialiased [text-rendering:optimizeLegibility]">
     <a

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -85,7 +85,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="/styles.css?v=20260725-responsive-meta" />
+    <link rel="stylesheet" href="/styles.css?v=20260801-github-header" />
   </head>
   <body class="bg-[var(--bg)] text-[var(--text)] antialiased [text-rendering:optimizeLegibility]">
     <a

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -85,7 +85,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="/styles.css?v=20260725-responsive-meta" />
+    <link rel="stylesheet" href="/styles.css?v=20260801-github-header" />
   </head>
   <body class="bg-[var(--bg)] text-[var(--text)] antialiased [text-rendering:optimizeLegibility]">
     <a

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -85,7 +85,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="/styles.css?v=20260725-responsive-meta" />
+    <link rel="stylesheet" href="/styles.css?v=20260801-github-header" />
   </head>
   <body class="bg-[var(--bg)] text-[var(--text)] antialiased [text-rendering:optimizeLegibility]">
     <a


### PR DESCRIPTION
The GitHub header button was present in the updated HTML but remained hidden in production because localized pages referenced the previous styles.css cache-buster. Update the stylesheet query string across all four language pages so the generated responsive utility is fetched after deployment.