### PR TITLE
Prevent CommandRunner deadlocks and run-loop re-entry

### DIFF
--- a/Sources/Capsomnia/SystemServices.swift
+++ b/Sources/Capsomnia/SystemServices.swift
@@ -10,35 +10,74 @@ struct LaunchAgentError: LocalizedError {
     }
 }
 
+private final class CommandOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        data.append(newData)
+    }
+
+    func string() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
 enum CommandRunner {
     static func run(_ executablePath: String, _ arguments: [String]) -> (status: Int32, stdout: String, stderr: String) {
         let process = Process()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
+        let stdoutBuffer = CommandOutputBuffer()
+        let stderrBuffer = CommandOutputBuffer()
+        let outputGroup = DispatchGroup()
+        let terminationSemaphore = DispatchSemaphore(value: 0)
 
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
+        process.terminationHandler = { _ in
+            terminationSemaphore.signal()
+        }
+
+        drain(stdoutPipe.fileHandleForReading, into: stdoutBuffer, group: outputGroup)
+        drain(stderrPipe.fileHandleForReading, into: stderrBuffer, group: outputGroup)
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
+            stdoutPipe.fileHandleForWriting.closeFile()
+            stderrPipe.fileHandleForWriting.closeFile()
+            outputGroup.wait()
             return (-1, "", "\(error)")
         }
 
+        terminationSemaphore.wait()
+        outputGroup.wait()
+
         return (
             process.terminationStatus,
-            read(stdoutPipe.fileHandleForReading),
-            read(stderrPipe.fileHandleForReading)
+            stdoutBuffer.string(),
+            stderrBuffer.string()
         )
     }
 
-    private static func read(_ handle: FileHandle) -> String {
-        let data = handle.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    private static func drain(
+        _ handle: FileHandle,
+        into buffer: CommandOutputBuffer,
+        group: DispatchGroup
+    ) {
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            defer { group.leave() }
+            buffer.append(handle.readDataToEndOfFile())
+        }
     }
 }
 

--- a/Tests/CapsomniaTests/CommandRunnerTests.swift
+++ b/Tests/CapsomniaTests/CommandRunnerTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+@testable import Capsomnia
+
+final class CommandRunnerTests: XCTestCase {
+    func testDrainsLargeStandardOutputAndErrorWithoutDeadlocking() {
+        let byteCount = 200_000
+        let script = """
+        /bin/dd if=/dev/zero bs=\(byteCount) count=1 2>/dev/null | /usr/bin/tr '\\0' o
+        /bin/dd if=/dev/zero bs=\(byteCount) count=1 2>/dev/null | /usr/bin/tr '\\0' e >&2
+        """
+
+        let result = CommandRunner.run("/bin/sh", ["-c", script])
+
+        XCTAssertEqual(result.status, 0)
+        XCTAssertEqual(result.stdout.utf8.count, byteCount)
+        XCTAssertEqual(result.stderr.utf8.count, byteCount)
+        XCTAssertEqual(result.stdout.first, "o")
+        XCTAssertEqual(result.stdout.last, "o")
+        XCTAssertEqual(result.stderr.first, "e")
+        XCTAssertEqual(result.stderr.last, "e")
+    }
+
+    @MainActor
+    func testWaitDoesNotRunMainRunLoopCallbacks() {
+        var timerDidFire = false
+        let timer = Timer(timeInterval: 0.01, repeats: false) { _ in
+            timerDidFire = true
+        }
+        RunLoop.main.add(timer, forMode: .default)
+        defer { timer.invalidate() }
+
+        let result = CommandRunner.run("/bin/sh", ["-c", "sleep 0.1"])
+
+        XCTAssertEqual(result.status, 0)
+        XCTAssertFalse(timerDidFire)
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        XCTAssertTrue(timerDidFire)
+    }
+}


### PR DESCRIPTION
## Summary

- drain standard output and standard error concurrently while a command runs
- wait for process termination without pumping the main run loop
- add regression coverage for pipe backpressure and run-loop re-entry

## Root cause

`CommandRunner` called `waitUntilExit()` before reading either output pipe. A child process that filled a pipe could block while writing, while Capsomnia blocked waiting for that child to exit.

`waitUntilExit()` can also run the default run loop while it waits. Because Capsomnia polls sleep state from the main thread, that allowed timer and input-source callbacks to re-enter `CommandRunner` and launch nested `pmset` processes.

## What changed

The runner now starts concurrent readers for both pipes, receives process termination through a handler and semaphore, then waits for both readers to reach EOF. The launch-failure path closes the parent write handles so those readers can finish. The existing synchronous API, exit status, and trimmed output behavior remain unchanged.

## Impact

Sleep-state polling no longer risks deadlocking on pipe backpressure or re-entering through the main run loop while a command is in progress.

## Validation

- `swift test --filter CommandRunnerTests`: 2 passed
- focused suite repeated 10 times: 20/20 test executions passed, with no hangs or flakes
- `swift test --sanitize=thread --filter CommandRunnerTests`: 2 passed, with no data-race report
- full `swift test`: 43 tests, 2 hardware-dependent skips, 0 failures
- `swift build -c release`: passed
- CI-equivalent helper validation, unsigned package build, and shell syntax checks: passed
