### PR TITLE
Add lid-closed guard for external Caps Lock turn-offs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+- Add an opt-in "Ignore Caps Lock turn-offs while the lid is closed" setting (default off) to Advanced Settings. While the lid is closed, Caps Lock turn-offs from external sources — such as a remote desktop client syncing its keyboard state to the host — are ignored and Caps Lock is re-asserted, so sleep prevention survives remote sessions. Turn-offs from the menu bar, the registered shortcut, and the auto-off timer stay effective, and opening the lid with Caps Lock off returns to normal sleep behavior. (#75)
+
 ## 3.0.0 - 2026-08-10
 
 - Add an optional auto-off timer with 15-minute through 8-hour presets, a one-minute to 24-hour custom picker, a live countdown, and an explicit restart action in Advanced Settings.

--- a/Sources/Capsomnia/AppConstants.swift
+++ b/Sources/Capsomnia/AppConstants.swift
@@ -92,6 +92,8 @@ struct AppStrings {
     let openAtLoginDesc: String
     let displaySleepOnLidClose: String
     let displaySleepOnLidCloseDesc: String
+    let ignoreExternalCapsLockOffWhileLidClosed: String
+    let ignoreExternalCapsLockOffWhileLidClosedDesc: String
     let autoOffTimer: String
     let autoOffTimerDesc: String
     let autoOffOff: String
@@ -144,6 +146,8 @@ struct AppStrings {
                 openAtLoginDesc: "Launch Capsomnia automatically after you sign in.",
                 displaySleepOnLidClose: "Turn display off when lid closes",
                 displaySleepOnLidCloseDesc: "When Capsomnia is on, let the display sleep after closing the lid only if no external display is connected.",
+                ignoreExternalCapsLockOffWhileLidClosed: "Ignore Caps Lock turn-offs while the lid is closed",
+                ignoreExternalCapsLockOffWhileLidClosedDesc: "While the lid is closed, sleep prevention stays on even if Caps Lock is turned off — for example by a remote desktop client syncing its keyboard state. The menu bar, the toggle shortcut, and the auto-off timer still turn it off.",
                 autoOffTimer: "Auto-off timer",
                 autoOffTimerDesc: "After the set time, Capsomnia turns awake mode off and puts your Mac to sleep.",
                 autoOffOff: "Off",
@@ -190,6 +194,8 @@ struct AppStrings {
                 openAtLoginDesc: "로그인하면 Capsomnia를 자동으로 실행합니다.",
                 displaySleepOnLidClose: "덮개를 닫을 때 화면 끄기",
                 displaySleepOnLidCloseDesc: "Capsomnia가 켜진 상태에서 덮개를 닫으면 외부 디스플레이가 연결되지 않은 경우에만 화면을 끕니다.",
+                ignoreExternalCapsLockOffWhileLidClosed: "덮개를 닫은 동안 Caps Lock에 의한 끄기 무시",
+                ignoreExternalCapsLockOffWhileLidClosedDesc: "덮개가 닫혀 있는 동안에는 Caps Lock이 꺼져도 잠자기 방지를 유지합니다. 원격 데스크톱 연결 등으로 의도치 않게 해제되는 것을 방지합니다. 메뉴 막대, 전환 단축키, 자동 종료 타이머로는 평소대로 끌 수 있습니다.",
                 autoOffTimer: "자동 종료 타이머",
                 autoOffTimerDesc: "설정한 시간이 지나면 절전 방지를 끄고 Mac을 잠자기 상태로 전환합니다.",
                 autoOffOff: "끄기",
@@ -236,6 +242,8 @@ struct AppStrings {
                 openAtLoginDesc: "サインイン後にCapsomniaを自動で起動します。",
                 displaySleepOnLidClose: "蓋を閉じたら画面をオフ",
                 displaySleepOnLidCloseDesc: "Capsomnia ON中は、外部ディスプレイが接続されていない場合のみ、蓋を閉じたら画面を暗くします。",
+                ignoreExternalCapsLockOffWhileLidClosed: "蓋を閉じている間はCaps Lockによるオフを無視",
+                ignoreExternalCapsLockOffWhileLidClosedDesc: "蓋を閉じている間は、Caps Lockがオフになってもスリープ抑止を維持します。リモートデスクトップ接続などで意図せず解除されるのを防ぎます。メニューバー・切り替えショートカット・自動オフタイマーからは通常どおりオフにできます。",
                 autoOffTimer: "自動オフタイマー",
                 autoOffTimerDesc: "設定した時間が経過すると、スリープ抑止を解除してMacをスリープさせます。",
                 autoOffOff: "オフ",
@@ -282,6 +290,8 @@ struct AppStrings {
                 openAtLoginDesc: "登录后自动启动 Capsomnia。",
                 displaySleepOnLidClose: "合盖时关闭显示屏",
                 displaySleepOnLidCloseDesc: "Capsomnia 开启时，仅在未连接外接显示器的情况下，合盖后让显示屏进入睡眠。",
+                ignoreExternalCapsLockOffWhileLidClosed: "合盖期间忽略 Caps Lock 的关闭操作",
+                ignoreExternalCapsLockOffWhileLidClosedDesc: "合盖期间，即使 Caps Lock 被关闭也会保持防睡眠，防止远程桌面连接等意外解除防睡眠。菜单栏、切换快捷键和自动关闭定时器仍可正常关闭。",
                 autoOffTimer: "自动关闭定时器",
                 autoOffTimerDesc: "设定时间结束后会关闭防睡眠并让 Mac 进入睡眠。",
                 autoOffOff: "关闭",
@@ -324,6 +334,7 @@ private enum PreferenceKey {
     static let language = "Language"
     static let launchAtLogin = "LaunchAtLogin"
     static let displaySleepOnLidClose = "DisplaySleepOnLidClose"
+    static let ignoreExternalCapsLockOffWhileLidClosed = "IgnoreExternalCapsLockOffWhileLidClosed"
     static let autoOffMinutes = "AutoOffMinutes"
     static let shortcutKeyCode = "ShortcutKeyCode"
     static let shortcutModifiers = "ShortcutModifiers"
@@ -342,6 +353,7 @@ enum Preferences {
             PreferenceKey.language: AppLanguage.defaultLanguage.rawValue,
             PreferenceKey.launchAtLogin: true,
             PreferenceKey.displaySleepOnLidClose: true,
+            PreferenceKey.ignoreExternalCapsLockOffWhileLidClosed: false,
             PreferenceKey.autoOffMinutes: 0,
             PreferenceKey.didCompleteInitialSetup: false,
             PreferenceKey.forceWelcomeOnNextLaunch: false
@@ -374,6 +386,18 @@ enum Preferences {
     static var displaySleepOnLidClose: Bool {
         get { defaults.bool(forKey: PreferenceKey.displaySleepOnLidClose) }
         set { defaults.set(newValue, forKey: PreferenceKey.displaySleepOnLidClose) }
+    }
+
+    /// While the lid is closed the built-in keyboard cannot be pressed, so a
+    /// Caps Lock turn-off observed in that window comes from an external
+    /// source (e.g. a remote desktop client syncing its keyboard state to the
+    /// host). When enabled, such turn-offs are ignored and Caps Lock is
+    /// re-asserted instead of releasing sleep prevention. Turn-offs from the
+    /// menu bar, the registered shortcut, and the auto-off timer stay
+    /// effective.
+    static var ignoreExternalCapsLockOffWhileLidClosed: Bool {
+        get { defaults.bool(forKey: PreferenceKey.ignoreExternalCapsLockOffWhileLidClosed) }
+        set { defaults.set(newValue, forKey: PreferenceKey.ignoreExternalCapsLockOffWhileLidClosed) }
     }
 
     /// Minutes after which awake mode turns itself off automatically.

--- a/Sources/Capsomnia/CapsomniaApp.swift
+++ b/Sources/Capsomnia/CapsomniaApp.swift
@@ -42,8 +42,13 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
     private let inputSourceNotificationDebounceInterval: TimeInterval = 0.1
     private let inputSourceInternalNotificationSuppression: TimeInterval = 0.5
     private let userCapsLockEventSuppressionInterval: TimeInterval = 0.5
+    // Longer than the input-source suppression window: the external-off guard
+    // consults this after the 350 ms off-debounce and possible polling delay,
+    // so an intentional turn-off must stay recognizable for a few seconds.
+    private let userActionExternalGuardBypassInterval: TimeInterval = 3
     private var suppressInputSourceNotificationsUntil = Date.distantPast
     private var suppressInputSourceRecoveryUntil = Date.distantPast
+    private var externalCapsLockOffGuardBypassUntil = Date.distantPast
     private let selectedKeyboardInputSourceChangedNotificationName = Notification.Name(
         kTISNotifySelectedKeyboardInputSourceChanged as String
     )
@@ -200,6 +205,9 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         cancelInputSourceRecovery()
         suppressInputSourceRecoveryUntil = Date().addingTimeInterval(
             userCapsLockEventSuppressionInterval
+        )
+        externalCapsLockOffGuardBypassUntil = Date().addingTimeInterval(
+            userActionExternalGuardBypassInterval
         )
         log("\(reason) user_action input_source_recovery_suppressed")
     }
@@ -425,6 +433,9 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
                 onDisplaySleepOnLidCloseChange: { [weak self] enabled in
                     self?.setDisplaySleepOnLidClose(enabled)
                 },
+                onIgnoreExternalCapsLockOffWhileLidClosedChange: { [weak self] enabled in
+                    self?.setIgnoreExternalCapsLockOffWhileLidClosed(enabled)
+                },
                 onAutoOffMinutesChange: { [weak self] minutes in
                     self?.setAutoOffMinutes(minutes)
                 },
@@ -515,6 +526,11 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
             didRequestDisplaySleepForClosedLid = false
         }
         log("preference display_sleep_on_lid_close=\(enabled ? "on" : "off")")
+    }
+
+    private func setIgnoreExternalCapsLockOffWhileLidClosed(_ enabled: Bool) {
+        Preferences.ignoreExternalCapsLockOffWhileLidClosed = enabled
+        log("preference ignore_external_capslock_off_while_lid_closed=\(enabled ? "on" : "off")")
     }
 
     /// Advance the auto-off timer and, if it has elapsed, turn awake mode off.
@@ -697,6 +713,16 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
         }
 
         if lastAppliedState == true, !capsLockOn {
+            if ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: Preferences.ignoreExternalCapsLockOffWhileLidClosed,
+                sleepPreventionActive: true,
+                recentUserAction: Date() < externalCapsLockOffGuardBypassUntil,
+                autoOffInProgress: isAutoOffToggleInFlight || autoOffSleepCoordinator.isPending,
+                clamshellClosed: ClamshellStateReader.isClosed()
+            ) {
+                reassertCapsLockAfterExternalOff(reason: reason)
+                return
+            }
             scheduleCapsLockOff(reason: reason)
             return
         }
@@ -707,6 +733,23 @@ final class Capsomnia: NSObject, NSApplicationDelegate {
             return
         }
         apply(capsLockOn: capsLockOn, reason: reason)
+    }
+
+    /// Re-assert Caps Lock after an external turn-off while the lid is
+    /// closed. Falls back to the normal turn-off path when the re-assert
+    /// fails, so a persistent failure can never wedge the app in a loop.
+    private func reassertCapsLockAfterExternalOff(reason: String) {
+        let result = SystemCapsLockController.set(true)
+        log(
+            "\(reason) external_capslock_off clamshell=closed"
+                + " reassert result=\(String(describing: result))"
+        )
+        guard result == .changed(to: true) else {
+            scheduleCapsLockOff(reason: reason)
+            return
+        }
+
+        apply(capsLockOn: true, reason: "\(reason)_external_off_reasserted")
     }
 
     private func scheduleCapsLockOff(reason: String) {

--- a/Sources/Capsomnia/SettingsWindowController.swift
+++ b/Sources/Capsomnia/SettingsWindowController.swift
@@ -65,6 +65,19 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let displaySleepOnLidCloseToggle = LEDToggle(
         isOn: Preferences.displaySleepOnLidClose
     )
+    private let externalCapsLockOffTitle = brandLabel(
+        size: 13,
+        weight: .medium,
+        color: Brand.text
+    )
+    private let externalCapsLockOffDesc = brandLabel(
+        size: 12,
+        color: Brand.textDim,
+        wraps: true
+    )
+    private let externalCapsLockOffToggle = LEDToggle(
+        isOn: Preferences.ignoreExternalCapsLockOffWhileLidClosed
+    )
 
     private let shortcutHeading = brandLabel(
         size: 11,
@@ -101,6 +114,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let onLanguageChange: (AppLanguage) -> Void
     private let onLaunchAtLoginChange: (Bool) -> Void
     private let onDisplaySleepOnLidCloseChange: (Bool) -> Void
+    private let onIgnoreExternalCapsLockOffWhileLidClosedChange: (Bool) -> Void
     private let onAutoOffMinutesChange: (Int) -> Void
     private let onAutoOffRestart: () -> Void
     private let autoOffDisplayProvider: () -> AutoOffDisplayState
@@ -115,6 +129,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         onLanguageChange: @escaping (AppLanguage) -> Void,
         onLaunchAtLoginChange: @escaping (Bool) -> Void,
         onDisplaySleepOnLidCloseChange: @escaping (Bool) -> Void,
+        onIgnoreExternalCapsLockOffWhileLidClosedChange: @escaping (Bool) -> Void,
         onAutoOffMinutesChange: @escaping (Int) -> Void,
         onAutoOffRestart: @escaping () -> Void,
         autoOffDisplayProvider: @escaping () -> AutoOffDisplayState,
@@ -127,6 +142,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         self.onLanguageChange = onLanguageChange
         self.onLaunchAtLoginChange = onLaunchAtLoginChange
         self.onDisplaySleepOnLidCloseChange = onDisplaySleepOnLidCloseChange
+        self.onIgnoreExternalCapsLockOffWhileLidClosedChange = onIgnoreExternalCapsLockOffWhileLidClosedChange
         self.onAutoOffMinutesChange = onAutoOffMinutesChange
         self.onAutoOffRestart = onAutoOffRestart
         self.autoOffDisplayProvider = autoOffDisplayProvider
@@ -200,6 +216,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         displaySleepOnLidCloseTitle.stringValue = strings.displaySleepOnLidClose
         displaySleepOnLidCloseDesc.stringValue = strings.displaySleepOnLidCloseDesc
         displaySleepOnLidCloseToggle.setAccessibilityLabel(strings.displaySleepOnLidClose)
+        externalCapsLockOffTitle.stringValue = strings.ignoreExternalCapsLockOffWhileLidClosed
+        externalCapsLockOffDesc.stringValue = strings.ignoreExternalCapsLockOffWhileLidClosedDesc
+        externalCapsLockOffToggle.setAccessibilityLabel(strings.ignoreExternalCapsLockOffWhileLidClosed)
         openAtLoginTitle.stringValue = strings.openAtLogin
         openAtLoginDesc.stringValue = strings.openAtLoginDesc
         openAtLoginToggle.setAccessibilityLabel(strings.openAtLogin)
@@ -576,6 +595,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             self?.onDisplaySleepOnLidCloseChange(enabled)
             self?.updateValues()
         }
+        externalCapsLockOffToggle.onToggle = { [weak self] enabled in
+            self?.onIgnoreExternalCapsLockOffWhileLidClosedChange(enabled)
+            self?.updateValues()
+        }
         openAtLoginToggle.onToggle = { [weak self] enabled in
             self?.onLaunchAtLoginChange(enabled)
             self?.updateValues()
@@ -585,6 +608,11 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             desc: displaySleepOnLidCloseDesc,
             accessory: displaySleepOnLidCloseToggle
         )
+        let externalCapsLockOffRow = settingRow(
+            title: externalCapsLockOffTitle,
+            desc: externalCapsLockOffDesc,
+            accessory: externalCapsLockOffToggle
+        )
         let openAtLoginRow = settingRow(
             title: openAtLoginTitle,
             desc: openAtLoginDesc,
@@ -593,6 +621,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         let card = brandCard()
         let rows: [NSView] = [
             displayRow, brandDivider(),
+            externalCapsLockOffRow, brandDivider(),
             openAtLoginRow
         ]
         let stack = NSStackView(views: rows)
@@ -667,6 +696,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         menuBarToggle.setOn(Preferences.showMenuBarIcon)
         languagePopUp.setSelected(Preferences.language.rawValue)
         displaySleepOnLidCloseToggle.setOn(Preferences.displaySleepOnLidClose)
+        externalCapsLockOffToggle.setOn(Preferences.ignoreExternalCapsLockOffWhileLidClosed)
         openAtLoginToggle.setOn(Preferences.launchAtLogin)
         shortcutRecorder.setShortcut(Preferences.keyboardShortcut)
         autoOffControl.setMinutes(Preferences.autoOffMinutes)

--- a/Sources/Capsomnia/SystemServices.swift
+++ b/Sources/Capsomnia/SystemServices.swift
@@ -182,3 +182,29 @@ enum DisplaySleepPolicy {
         externalDisplayConnected == false
     }
 }
+
+enum ExternalCapsLockOffPolicy {
+    /// Decide whether a Caps Lock turn-off should be treated as external and
+    /// re-asserted instead of followed. While the lid is closed the built-in
+    /// keyboard cannot be pressed, so a turn-off observed in that window
+    /// comes from an external source unless the app itself initiated it.
+    ///
+    /// - An elapsed auto-off timer is an explicit turn-off that must proceed
+    ///   to system sleep, so an in-progress auto-off always wins over the
+    ///   guard.
+    /// - `clamshellClosed == nil` (state unavailable) fails open: the
+    ///   turn-off is honored as usual.
+    static func shouldReassert(
+        preferenceEnabled: Bool,
+        sleepPreventionActive: Bool,
+        recentUserAction: Bool,
+        autoOffInProgress: Bool,
+        clamshellClosed: Bool?
+    ) -> Bool {
+        preferenceEnabled
+            && sleepPreventionActive
+            && !recentUserAction
+            && !autoOffInProgress
+            && clamshellClosed == true
+    }
+}

--- a/Tests/CapsomniaTests/ExternalCapsLockOffPolicyTests.swift
+++ b/Tests/CapsomniaTests/ExternalCapsLockOffPolicyTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Capsomnia
+
+final class ExternalCapsLockOffPolicyTests: XCTestCase {
+    func testReassertsWhenLidClosedWithoutUserAction() {
+        XCTAssertTrue(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: true,
+                recentUserAction: false,
+                autoOffInProgress: false,
+                clamshellClosed: true
+            )
+        )
+    }
+
+    func testHonorsTurnOffWhenPreferenceDisabled() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: false,
+                sleepPreventionActive: true,
+                recentUserAction: false,
+                autoOffInProgress: false,
+                clamshellClosed: true
+            )
+        )
+    }
+
+    func testHonorsTurnOffAfterRecentUserAction() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: true,
+                recentUserAction: true,
+                autoOffInProgress: false,
+                clamshellClosed: true
+            )
+        )
+    }
+
+    func testHonorsTurnOffWhileAutoOffInProgress() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: true,
+                recentUserAction: false,
+                autoOffInProgress: true,
+                clamshellClosed: true
+            )
+        )
+    }
+
+    func testHonorsTurnOffWhenLidOpen() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: true,
+                recentUserAction: false,
+                autoOffInProgress: false,
+                clamshellClosed: false
+            )
+        )
+    }
+
+    func testHonorsTurnOffWhenClamshellStateUnavailable() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: true,
+                recentUserAction: false,
+                autoOffInProgress: false,
+                clamshellClosed: nil
+            )
+        )
+    }
+
+    func testHonorsTurnOffWhenSleepPreventionInactive() {
+        XCTAssertFalse(
+            ExternalCapsLockOffPolicy.shouldReassert(
+                preferenceEnabled: true,
+                sleepPreventionActive: false,
+                recentUserAction: false,
+                autoOffInProgress: false,
+                clamshellClosed: true
+            )
+        )
+    }
+}

--- a/Tests/CapsomniaTests/LocalizationTests.swift
+++ b/Tests/CapsomniaTests/LocalizationTests.swift
@@ -27,6 +27,8 @@ final class LocalizationTests: XCTestCase {
             XCTAssertFalse(strings.toggleCapsLock.isEmpty)
             XCTAssertFalse(strings.showMenuBarIcon.isEmpty)
             XCTAssertFalse(strings.displaySleepOnLidClose.isEmpty)
+            XCTAssertFalse(strings.ignoreExternalCapsLockOffWhileLidClosed.isEmpty)
+            XCTAssertFalse(strings.ignoreExternalCapsLockOffWhileLidClosedDesc.isEmpty)
             XCTAssertFalse(strings.openAtLogin.isEmpty)
             XCTAssertFalse(strings.language.isEmpty)
             XCTAssertFalse(strings.advancedSettings.isEmpty)

--- a/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
+++ b/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
@@ -357,6 +357,7 @@ final class SettingsWindowControllerTests: XCTestCase {
             onLanguageChange: { _ in },
             onLaunchAtLoginChange: { _ in },
             onDisplaySleepOnLidCloseChange: { _ in },
+            onIgnoreExternalCapsLockOffWhileLidClosedChange: { _ in },
             onAutoOffMinutesChange: { _ in },
             onAutoOffRestart: {},
             autoOffDisplayProvider: autoOffDisplayProvider,


### PR DESCRIPTION
Closes #75

## 概要 / Summary

**JA:** #75 でご提案した「蓋を閉じている間は、外部要因による Caps Lock の変更からスリープ抑止を保護する」設定を追加します。設定名は「**蓋を閉じている間は Caps Lock によるオフを無視**」(詳細設定 > システム動作、デフォルト OFF) としました。蓋を閉じている間に観測された Caps Lock のオフを外部由来と判定して再アサートし、スリープ抑止を維持します。ガードはオフ方向のみで、外部からのオンは従来どおり通ります。

**EN:** Adds the opt-in setting proposed in #75: "**Ignore Caps Lock turn-offs while the lid is closed**" (Advanced Settings > System Behavior, default OFF). A Caps Lock turn-off observed while the lid is closed is attributed to an external source and re-asserted, keeping sleep prevention on. The guard only covers the off direction; external turn-ons pass through as before.

## ご指定条件への対応 / Maintainer requirements

- **自動オフタイマー**: タイマー満了は明示的なオフとして通します。判定に `AutoOffSleepCoordinator.isPending` を含めているため、デバウンスやリトライがどれだけ延びてもガードが割り込みません（Caps Lock オフ → `SleepDisabled=0` 確認 → スリープ要求、の既存動作を維持）
- **蓋を開いた時**: 判定条件が `clamshellClosed == true` を要求するため、蓋を開いた時点で保護は自動的に終了し、通常のオフ経路に戻ります（下記テスト A で実測済み）
- **最新 main ベース**: f110641 ベースです

## 実装 / Implementation

- 判定は既存の policy enum パターン（`DisplaySleepPolicy` 等）に合わせ、純粋関数 `ExternalCapsLockOffPolicy.shouldReassert` に切り出しました
- メニューバー・登録ショートカット・物理キーは既存の `suppressInputSourceRecoveryForUserAction()` に相乗りする形で「意図的な操作」と判定し、数秒間ガードを迂回します
- 再アサートに失敗した場合は通常のオフ経路へフォールバックし、外部要因と争い続けるループを構造的に防いでいます
- 文言は 4 言語とも各ブロックの既存語彙（スリープ抑止 / sleep prevention / 防睡眠 / 잠자기 방지）に合わせています
- 設定の setter が `setDisplaySleepOnLidClose` と違い再評価を呼ばないのは、ガードが 250ms のポーリングで毎回評価されるためです（見逃しの一回性がない）
- UI は「システム動作」カードに置きました（蓋関連の設定つながり）。別の場所がよろしければ移動します

## テスト / Testing

`swift test`: 71 件パス（policy の判定表テスト 7 件を追加）

実機（MacBook Pro M1 Max, macOS 26.5.2, Jump Desktop 環境と `IOHIDSetModifierLockState` による外部変更の再現）:

| ケース / Case | 結果 / Result |
|---|---|
| 蓋クローズ + 外部オフ / lid closed + external off | 再アサートされ抑止維持 / re-asserted, `SleepDisabled` stays 1 ✅ |
| 蓋オープン + 外部オフ / lid open + external off | 通常どおりオフ（保護終了） / passes through ✅ |
| 蓋クローズ + メニューからオフ / lid closed + menu turn-off | 意図どおりオフのまま / stays off ✅ |
| 外部オン / external on | 従来どおりオン / passes through ✅ |
| 設定トグルの UI 配線 / settings toggle wiring | 反映・ログ出力を確認 ✅ |
| 入力ソース切替復旧（#63）との共存 / coexistence with #63 recovery | 衝突なし / no conflict ✅ |

自動オフタイマー満了との組み合わせのみ、実スリープを伴うため実機では未検証です（単体テストとコードトレースで確認）。ガードのコア実装は 2026-08-10 から蓋クローズ + リモート接続環境で常用しており、外部オフの再アサート発動をログで確認しています。

Only the auto-off-expiry combination was not exercised on hardware (it actually sleeps the Mac); it is covered by the unit tests and code tracing. The core guard has been in daily closed-lid remote use since 2026-08-10.

## 補足 / Notes

- `autoOffInProgress` の `isAutoOffToggleInFlight` 項は現在の呼び出し位置では常に false ですが（上流で早期 return 済み）、将来の変更でガードが壊れないよう防御的に含めています
- 今回の変更とは無関係ですが、韓国語ブロックの既存文言に「절전 방지」（`autoOffTimerDesc`）と「잠자기 방지」（tooltip 系）の揺れがあるようです。本 PR の新規文言は tooltip 系に合わせて「잠자기 방지」を使用しています

設定名・文言・UI の置き場所はご意向に合わせて調整します。ご確認よろしくお願いします。
