### PR TITLE
Release Capsomnia 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 3.1.0 - 2026-08-13
+
 - Add Intel Mac source-install support for macOS 13.5 or later with Swift 5.9, while keeping the signed and notarized package Apple silicon-only on macOS 14 or later.
 - Add an opt-in "Ignore Caps Lock turn-offs while the lid is closed" setting (default off) to Advanced Settings. While the lid is closed, Caps Lock turn-offs from external sources — such as a remote desktop client syncing its keyboard state to the host — are ignored and Caps Lock is re-asserted, so sleep prevention survives remote sessions. Turn-offs from the menu bar, the registered shortcut, and the auto-off timer stay effective, and opening the lid with Caps Lock off returns to normal sleep behavior. (#75)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `3.0.0`
+現在のバージョン: `3.1.0`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 
@@ -77,6 +77,7 @@ cd Capsomnia
 - 自動オフタイマー（任意）: 15分〜8時間のプリセット、または1分〜24時間のカスタム時間を設定できます。満了するとCapsomniaをオフにし、スリープ抑止の解除を確認してからMacを直ちにスリープさせます。
 - Caps Lock オフ: 通常のスリープ動作に戻ります。
 - Capsomniaオン中に蓋を閉じた時: 作業を走らせたまま画面だけスリープします。
+- 蓋を閉じている間はCaps Lockによるオフを無視（任意・既定オフ）: リモートデスクトップ接続などでCaps Lockが意図せずオフになってもスリープ抑止を維持し、メニューバー・切り替えショートカット・自動オフタイマーからは通常どおりオフにできます。
 - アプリ終了時: 通常のスリープ動作へ戻します。
 
 長時間動くローカルジョブ、AI コーディングエージェント、SSH、ビルド、ダウンロード、放置スクリプトなどを止めたくないときに使う想定です。

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `3.0.0`
+현재 버전: `3.1.0`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 
@@ -77,6 +77,7 @@ cd Capsomnia
 - 자동 종료 타이머(선택 사항): 15분~8시간 프리셋 또는 1분~24시간 사용자 지정 시간을 설정할 수 있습니다. 시간이 끝나면 Capsomnia를 끄고 잠자기 방지가 해제되었는지 확인한 뒤 Mac을 즉시 잠자기 상태로 전환합니다.
 - Caps Lock 끄기: 평소 잠자기 동작으로 돌아갑니다.
 - Capsomnia가 켜진 상태에서 덮개 닫기: 외부 디스플레이가 연결되어 있지 않을 때만 디스플레이를 끄고 작업은 계속 돌립니다.
+- 덮개를 닫은 동안 Caps Lock에 의한 끄기 무시(선택 사항, 기본값: 꺼짐): 원격 데스크톱 연결 등으로 Caps Lock이 의도치 않게 꺼져도 잠자기 방지를 유지하며, 메뉴 막대·전환 단축키·자동 종료 타이머로는 평소대로 끌 수 있습니다.
 - 앱 종료: 평소 잠자기 동작으로 돌아갑니다.
 
 오래 걸리는 로컬 작업, AI 코딩 에이전트, SSH 세션, 빌드, 다운로드, 무인 스크립트를 실행할 때 유용합니다.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `3.0.0`
+Current version: `3.1.0`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 
@@ -77,6 +77,7 @@ The source installer builds `Capsomnia.app` locally, places it in `~/Application
 - Auto-off timer (optional): choose a preset from 15 minutes to 8 hours or a custom duration from 1 minute to 24 hours. When time expires, Capsomnia turns off, confirms that sleep prevention is released, and immediately puts the Mac to sleep.
 - Caps Lock off: restores normal sleep behavior.
 - Lid closed while Capsomnia is on: puts the display to sleep only when no external display is connected, while work keeps running.
+- Ignore Caps Lock turn-offs while the lid is closed (optional, off by default): keeps sleep prevention active when a remote desktop client or another external source turns Caps Lock off; the menu bar, toggle shortcut, and auto-off timer still turn it off normally.
 - Quitting the app restores normal sleep behavior.
 
 Capsomnia is useful for long-running local jobs, AI coding agents, SSH sessions, builds, downloads, and unattended scripts.

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`3.0.0`
+当前版本：`3.1.0`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 
@@ -79,6 +79,7 @@ cd Capsomnia
 - 自动关闭定时器（可选）：可选择15分钟到8小时的预设，或设置1分钟到24小时的自定义时长。到时后，Capsomnia会关闭，确认防休眠已解除，然后立即让Mac进入睡眠。
 - Caps Lock关闭：恢复正常睡眠行为。
 - Capsomnia开启时合盖：仅在未连接外接显示器时关闭显示屏，后台任务继续运行。
+- 合盖期间忽略 Caps Lock 的关闭操作（可选，默认关闭）：远程桌面客户端或其他外部来源意外关闭 Caps Lock 时仍保持防睡眠；菜单栏、切换快捷键和自动关闭定时器仍可正常关闭。
 - 退出应用：恢复正常睡眠行为。
 
 Capsomnia适合长时间运行的本地任务、AI编程智能体、SSH会话、构建、下载和无人值守脚本。

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.0.0",
+            "softwareVersion": "3.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {
@@ -324,7 +324,7 @@
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">Closed lid</p>
                 <h3 class="mb-2 text-[1.05rem] font-bold">Keeps work running with the lid closed</h3>
-                <p class="text-[0.95rem] text-[var(--text-dim)]">Turn Caps Lock on, close the MacBook, and local jobs keep running. Your Mac can remain reachable over SSH when remote login and networking are available.</p>
+                <p class="text-[0.95rem] text-[var(--text-dim)]">Turn Caps Lock on, close the MacBook, and local jobs keep running. Your Mac can remain reachable over SSH when remote login and networking are available. An optional setting (off by default) keeps sleep prevention active if a remote desktop client turns Caps Lock off while the lid is closed.</p>
               </article>
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">Physical state</p>

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.0.0",
+            "softwareVersion": "3.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {
@@ -324,7 +324,7 @@
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">Closed lid</p>
                 <h3 class="mb-2 text-[1.05rem] font-bold">蓋を閉じても処理が続行</h3>
-                <p class="text-[0.95rem] text-[var(--text-dim)]">Caps Lockをオンにすれば、MacBookの蓋を閉じてもローカル処理を走らせ続けます。SSH接続先としても使い続けられます。</p>
+                <p class="text-[0.95rem] text-[var(--text-dim)]">Caps Lockをオンにすれば、MacBookの蓋を閉じてもローカル処理を走らせ続けます。SSH接続先としても使い続けられます。詳細設定の「蓋を閉じている間はCaps Lockによるオフを無視」（既定オフ）を有効にすると、蓋を閉じている間にリモートデスクトップ接続がCaps Lockをオフにしても、スリープ抑止を維持します。</p>
               </article>
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">Physical state</p>

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.0.0",
+            "softwareVersion": "3.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {
@@ -324,7 +324,7 @@
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">덮개 닫기</p>
                 <h3 class="mb-2 text-[1.05rem] font-bold">덮개를 닫아도 작업은 계속됩니다</h3>
-                <p class="text-[0.95rem] text-[var(--text-dim)]">Caps Lock을 켜고 MacBook 덮개를 닫아도 로컬 작업은 계속 실행됩니다. 원격 로그인과 네트워크가 켜져 있으면 SSH 접속도 유지됩니다.</p>
+                <p class="text-[0.95rem] text-[var(--text-dim)]">Caps Lock을 켜고 MacBook 덮개를 닫아도 로컬 작업은 계속 실행됩니다. 원격 로그인과 네트워크가 켜져 있으면 SSH 접속도 유지됩니다. 고급 설정에서 ‘덮개를 닫은 동안 Caps Lock에 의한 끄기 무시’(기본값: 꺼짐)를 활성화하면, 덮개를 닫은 동안 원격 데스크톱 연결이 Caps Lock을 꺼도 잠자기 방지를 유지합니다.</p>
               </article>
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">물리 표시</p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,7 +7,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -18,7 +18,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -29,7 +29,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -40,7 +40,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.0.0",
+            "softwareVersion": "3.1.0",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {
@@ -324,7 +324,7 @@
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">合盖运行</p>
                 <h3 class="mb-2 text-[1.05rem] font-bold">合盖后任务继续运行</h3>
-                <p class="text-[0.95rem] text-[var(--text-dim)]">开启 Caps Lock 并合上 MacBook，本地任务仍会继续运行。在已启用远程登录且网络可用时，你也可以继续通过 SSH 访问 Mac。</p>
+                <p class="text-[0.95rem] text-[var(--text-dim)]">开启 Caps Lock 并合上 MacBook，本地任务仍会继续运行。在已启用远程登录且网络可用时，你也可以继续通过 SSH 访问 Mac。在高级设置中启用“合盖期间忽略 Caps Lock 的关闭操作”（默认关闭）后，即使远程桌面连接在合盖期间关闭 Caps Lock，也会继续保持防睡眠。</p>
               </article>
               <article class="rounded-[14px] border border-[var(--border)] bg-[var(--surface)] p-5">
                 <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-normal text-[var(--led)]">实体状态</p>

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>3.0.0</string>
+  <string>3.1.0</string>
 
   <key>CFBundleVersion</key>
-  <string>3.0.0</string>
+  <string>3.1.0</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>13.5</string>


### PR DESCRIPTION
## 概要

Capsomnia 3.1.0のリリース準備です。

- Intel Mac / macOS 13.5 / Swift 5.9のソースインストール対応を反映
- 蓋閉じ中に外部からCaps Lockがオフにされた際のスリープ抑止を維持する任意設定を反映
- バージョン表記、CHANGELOG、4言語のREADMEとサイトを更新

署名・公証済みpkgは従来どおりApple silicon・macOS 14以降向けです。

## 検証

- Swift tests: 71 passed, 2 hardware-only tests skipped
- Site / Worker tests: 20 passed
- Release build with warnings as errors: passed
- Unsigned package structure and root ownership validation: passed