### PR TITLE
Avoid restarting an unchanged auto-off timer

### DIFF
--- a/Sources/Capsomnia/AutoOffTimerControl.swift
+++ b/Sources/Capsomnia/AutoOffTimerControl.swift
@@ -318,19 +318,29 @@ final class AutoOffTimerControl: NSView {
 
     private func selectPreset(_ value: Int) {
         customPopover.close()
+        let changed = minutes != value
         isCustom = false
         minutes = value
         refreshSelection()
-        onMinutesChange?(value)
+        if changed {
+            onMinutesChange?(value)
+        }
         renderDisplay()
     }
 
     private func selectCustom() {
         isCustom = true
-        minutes = min(max(customMinutes, AutoOffPreset.minCustomMinutes), AutoOffPreset.maxCustomMinutes)
+        let selectedMinutes = min(
+            max(customMinutes, AutoOffPreset.minCustomMinutes),
+            AutoOffPreset.maxCustomMinutes
+        )
+        let changed = minutes != selectedMinutes
+        minutes = selectedMinutes
         customMinutes = minutes
         refreshSelection()
-        onMinutesChange?(minutes)
+        if changed {
+            onMinutesChange?(minutes)
+        }
         renderDisplay()
         if customPopover.isShown {
             customPopover.close()

--- a/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
+++ b/Tests/CapsomniaTests/SettingsWindowControllerTests.swift
@@ -314,6 +314,69 @@ final class SettingsWindowControllerTests: XCTestCase {
         }
     }
 
+    func testReselectingCurrentAutoOffDurationDoesNotReportAChange() throws {
+        let previousLanguage = Preferences.language
+        let previousMinutes = Preferences.autoOffMinutes
+        Preferences.language = .english
+        Preferences.autoOffMinutes = 60
+        defer {
+            Preferences.language = previousLanguage
+            Preferences.autoOffMinutes = previousMinutes
+        }
+
+        var reportedMinutes: [Int] = []
+        _ = NSApplication.shared
+        let controller = makeController(
+            onAutoOffMinutesChange: { reportedMinutes.append($0) }
+        )
+        defer { controller.close() }
+
+        controller.show(page: .advancedSettings)
+        let contentView = try XCTUnwrap(controller.window?.contentView)
+        contentView.layoutSubtreeIfNeeded()
+        let selectedPreset = try XCTUnwrap(
+            view(
+                in: contentView,
+                accessibilityLabel: AutoOffFormatter.durationLabel(minutes: 60)
+            )
+        )
+
+        XCTAssertTrue(selectedPreset.accessibilityPerformPress())
+        XCTAssertTrue(reportedMinutes.isEmpty)
+    }
+
+    func testTogglingCurrentCustomAutoOffEditorDoesNotReportAChange() throws {
+        let previousLanguage = Preferences.language
+        let previousMinutes = Preferences.autoOffMinutes
+        Preferences.language = .english
+        Preferences.autoOffMinutes = 45
+        defer {
+            Preferences.language = previousLanguage
+            Preferences.autoOffMinutes = previousMinutes
+        }
+
+        var reportedMinutes: [Int] = []
+        _ = NSApplication.shared
+        let controller = makeController(
+            onAutoOffMinutesChange: { reportedMinutes.append($0) }
+        )
+        defer { controller.close() }
+
+        controller.show(page: .advancedSettings)
+        let contentView = try XCTUnwrap(controller.window?.contentView)
+        contentView.layoutSubtreeIfNeeded()
+        let customChip = try XCTUnwrap(
+            view(
+                in: contentView,
+                accessibilityLabel: AppStrings.localized(for: .english).autoOffCustom
+            )
+        )
+
+        XCTAssertTrue(customChip.accessibilityPerformPress())
+        XCTAssertTrue(customChip.accessibilityPerformPress())
+        XCTAssertTrue(reportedMinutes.isEmpty)
+    }
+
     func testRestartButtonShownWhenTimerIsSetAndHiddenWhenOff() throws {
         let previousLanguage = Preferences.language
         let previousMinutes = Preferences.autoOffMinutes
@@ -353,6 +416,7 @@ final class SettingsWindowControllerTests: XCTestCase {
 
     private func makeController(
         onKeyboardShortcutRecordingChange: @escaping (Bool) -> Void = { _ in },
+        onAutoOffMinutesChange: @escaping (Int) -> Void = { _ in },
         autoOffDisplayProvider: @escaping () -> AutoOffDisplayState = { .idle(minutes: 0) }
     ) -> SettingsWindowController {
         SettingsWindowController(
@@ -362,7 +426,7 @@ final class SettingsWindowControllerTests: XCTestCase {
             onLaunchAtLoginChange: { _ in },
             onDisplaySleepOnLidCloseChange: { _ in },
             onIgnoreExternalCapsLockOffWhileLidClosedChange: { _ in },
-            onAutoOffMinutesChange: { _ in },
+            onAutoOffMinutesChange: onAutoOffMinutesChange,
             onAutoOffRestart: {},
             autoOffDisplayProvider: autoOffDisplayProvider,
             onKeyboardShortcutChange: { _ in true },


### PR DESCRIPTION
## Summary

- notify the app only when selecting a preset changes the effective auto-off duration
- allow the current Custom editor to open and close without reporting an unchanged duration
- keep explicit countdown resets on the existing Restart action
- add UI regression coverage for preset reselection and Custom editor toggling

## Verification

- `swift test` (73 tests, 2 skipped, 0 failures)
- `swift build -c release`
- `SKIP_SIGNING=true ./scripts/build-pkg.sh "$TMPDIR/capsomnia-pkg-auto-off-selection"`
- `git diff --check`