### PR TITLE
Release Capsomnia 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Capsomnia will be documented in this file.
 
 ## Unreleased
 
+## 3.1.1 - 2026-08-16
+
+- Prevent reselecting the current auto-off preset or opening and closing the unchanged Custom editor from restarting an active countdown. Use the existing Restart action for intentional resets. (#84)
+
 ## 3.1.0 - 2026-08-13
 
 - Add Intel Mac source-install support for macOS 13.5 or later with Swift 5.9, while keeping the signed and notarized package Apple silicon-only on macOS 14 or later.

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-現在のバージョン: `3.1.0`
+現在のバージョン: `3.1.1`
 
 [English README](README.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 라이선스" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-현재 버전: `3.1.0`
+현재 버전: `3.1.1`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-Current version: `3.1.0`
+Current version: `3.1.1`
 
 [日本語 README](README.ja.md) · [简体中文 README](README.zh-Hans.md) · [한국어 README](README.ko.md)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -20,7 +20,7 @@
   <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-b7ff3c?style=flat-square&labelColor=111111"></a>
 </p>
 
-当前版本：`3.1.0`
+当前版本：`3.1.1`
 
 [English README](README.md) · [日本語 README](README.ja.md) · [한국어 README](README.ko.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.1.0",
+            "softwareVersion": "3.1.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.1.0",
+            "softwareVersion": "3.1.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.1.0",
+            "softwareVersion": "3.1.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,7 +7,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -18,7 +18,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -29,7 +29,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -40,7 +40,7 @@
     <xhtml:link rel="alternate" hreflang="zh-Hans" href="https://capsomnia.com/zh-hans/" />
     <xhtml:link rel="alternate" hreflang="ko" href="https://capsomnia.com/ko/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://capsomnia.com/" />
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -63,7 +63,7 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "DeveloperTool",
             "operatingSystem": "macOS 14 or later on Apple silicon",
-            "softwareVersion": "3.1.0",
+            "softwareVersion": "3.1.1",
             "license": "https://github.com/fuji-mak/Capsomnia/blob/main/LICENSE",
             "isAccessibleForFree": true,
             "offers": {

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -28,10 +28,10 @@
   <string>APPL</string>
 
   <key>CFBundleShortVersionString</key>
-  <string>3.1.0</string>
+  <string>3.1.1</string>
 
   <key>CFBundleVersion</key>
-  <string>3.1.0</string>
+  <string>3.1.1</string>
 
   <key>LSMinimumSystemVersion</key>
   <string>13.5</string>


### PR DESCRIPTION
## 概要\n\nCapsomnia 3.1.1のリリース準備です。\n\n- 同じ自動オフ時間の再選択や、変更なしのCustomエディタ開閉で進行中のカウントダウンが再スタートしないよう修正\n- 明示的な再スタートは既存のRestart操作に維持\n- バージョン表記、CHANGELOG、サイトmetadataを更新\n\n署名・公証済みpkgは従来どおりApple silicon・macOS 14以降向けです。\n\n## 検証\n\n- Swift tests: 73 passed, 2 hardware-only skipped\n- Site / Worker tests: 20 passed\n- Release build with warnings as errors: passed\n- Unsigned package structure/root ownership: passed