### PR TITLE
Preserve the open-at-login preference during upgrades

### DIFF
--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -156,7 +156,12 @@ fi
 /bin/sleep 1
 /usr/bin/sudo -u "$console_user" /usr/bin/defaults write "$LABEL" ForceWelcomeOnNextLaunch -bool true 2>/dev/null || true
 /bin/launchctl bootstrap "gui/$console_uid" "$SYSTEM_LAUNCH_AGENT" 2>/dev/null || true
-/bin/launchctl enable "gui/$console_uid/$LABEL" 2>/dev/null || true
+launch_at_login="$(/usr/bin/sudo -u "$console_user" /usr/bin/defaults read "$LABEL" LaunchAtLogin 2>/dev/null || true)"
+if [[ "$launch_at_login" == "0" ]]; then
+  /bin/launchctl disable "gui/$console_uid/$LABEL" 2>/dev/null || true
+else
+  /bin/launchctl enable "gui/$console_uid/$LABEL" 2>/dev/null || true
+fi
 
 exit 0
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,6 +94,11 @@ EOF
 
 /usr/bin/defaults write "$LABEL" ForceWelcomeOnNextLaunch -bool true
 launchctl bootstrap "gui/$(id -u)" "$LAUNCH_AGENT"
-launchctl enable "gui/$(id -u)/$LABEL"
+launch_at_login="$(/usr/bin/defaults read "$LABEL" LaunchAtLogin 2>/dev/null || true)"
+if [[ "$launch_at_login" == "0" ]]; then
+  launchctl disable "gui/$(id -u)/$LABEL"
+else
+  launchctl enable "gui/$(id -u)/$LABEL"
+fi
 
 echo "Installed $APP_NAME."


### PR DESCRIPTION
## Summary

- preserve an explicitly disabled “Open at login” preference during package upgrades
- apply the same preference-aware launchd state in both installer paths
- retain the existing enabled-by-default behavior for new installations and users without a stored preference

## Problem

Both installer paths unconditionally enabled the launch agent after installation.

As a result, a user who disabled “Open at login” could upgrade Capsomnia and end up with:

- the stored preference still set to OFF
- the launch agent enabled
- Capsomnia launching at login despite the Settings UI showing OFF

## Implementation

Before setting the launchd state, each installer reads the existing `LaunchAtLogin` preference:

- an explicit `0` disables the launch agent
- `1` or a missing value enables it, preserving the current default behavior

## Verification

- reproduced the mismatch using the installer’s existing unconditional `launchctl enable`
- verified an explicit OFF preference now leaves launchd disabled
- verified a missing preference still leaves launchd enabled for a new installation
- `zsh -n scripts/build-pkg.sh`
- `zsh -n scripts/install.sh`
- `swift test` — 73 tests, 2 skipped, 0 failures
- unsigned package build succeeded
- `git diff --check`