### PR TITLE
Link Capsomnia structured data to creator profiles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,8 +73,16 @@
             },
             "author": {
               "@type": "Person",
+              "@id": "https://fuji-maki.me/#person",
               "name": "Taketo Fujimaki",
-              "url": "https://fuji-maki.me/"
+              "alternateName": "藤巻雄飛",
+              "url": "https://fuji-maki.me/",
+              "sameAs": [
+                "https://github.com/fuji-mak",
+                "https://zenn.dev/fujimac",
+                "https://note.com/legal_shark926",
+                "https://x.com/tf_makimaki"
+              ]
             },
             "isPartOf": {
               "@id": "https://capsomnia.com/#website"

--- a/docs/ja/index.html
+++ b/docs/ja/index.html
@@ -73,8 +73,16 @@
             },
             "author": {
               "@type": "Person",
-              "name": "Taketo Fujimaki",
-              "url": "https://fuji-maki.me/"
+              "@id": "https://fuji-maki.me/#person",
+              "name": "藤巻雄飛",
+              "alternateName": "Taketo Fujimaki",
+              "url": "https://fuji-maki.me/",
+              "sameAs": [
+                "https://github.com/fuji-mak",
+                "https://zenn.dev/fujimac",
+                "https://note.com/legal_shark926",
+                "https://x.com/tf_makimaki"
+              ]
             },
             "isPartOf": {
               "@id": "https://capsomnia.com/ja/#website"

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -73,8 +73,16 @@
             },
             "author": {
               "@type": "Person",
+              "@id": "https://fuji-maki.me/#person",
               "name": "Taketo Fujimaki",
-              "url": "https://fuji-maki.me/"
+              "alternateName": "藤巻雄飛",
+              "url": "https://fuji-maki.me/",
+              "sameAs": [
+                "https://github.com/fuji-mak",
+                "https://zenn.dev/fujimac",
+                "https://note.com/legal_shark926",
+                "https://x.com/tf_makimaki"
+              ]
             },
             "isPartOf": {
               "@id": "https://capsomnia.com/#website"

--- a/docs/zh-hans/index.html
+++ b/docs/zh-hans/index.html
@@ -73,8 +73,16 @@
             },
             "author": {
               "@type": "Person",
+              "@id": "https://fuji-maki.me/#person",
               "name": "Taketo Fujimaki",
-              "url": "https://fuji-maki.me/"
+              "alternateName": "藤巻雄飛",
+              "url": "https://fuji-maki.me/",
+              "sameAs": [
+                "https://github.com/fuji-mak",
+                "https://zenn.dev/fujimac",
+                "https://note.com/legal_shark926",
+                "https://x.com/tf_makimaki"
+              ]
             },
             "isPartOf": {
               "@id": "https://capsomnia.com/zh-hans/#website"


### PR DESCRIPTION
## Summary
- Link the SoftwareApplication author to the canonical Fujimaki person entity.
- Add Japanese/English alternate names.
- Connect the creator to GitHub, Zenn, note, and X with sameAs.

## Validation
- npm run test:site