### PR TITLE
Preserve code signatures in release package

### DIFF
--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -16,7 +16,6 @@ PKGBUILD_FILTERS=(
   --filter '(^|/)\.DS_Store$'
   --filter '(^|/)\.svn($|/)'
   --filter '(^|/)CVS($|/)'
-  --filter '(^|/)\._'
 )
 
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$ROOT_DIR/resources/Info.plist")"
@@ -24,9 +23,7 @@ WORK_DIR="$(/usr/bin/mktemp -d)"
 PAYLOAD_ROOT="$WORK_DIR/payload"
 SCRIPTS_DIR="$WORK_DIR/scripts"
 COMPONENT_PLIST="$WORK_DIR/components.plist"
-BOM_LIST="$WORK_DIR/bom-list.txt"
 UNSIGNED_PKG="$DIST_DIR/$APP_NAME-$VERSION-unsigned.pkg"
-SANITIZED_UNSIGNED_PKG="$WORK_DIR/$APP_NAME-$VERSION-sanitized-unsigned.pkg"
 SIGNED_PKG="$DIST_DIR/$APP_NAME-$VERSION.pkg"
 
 cleanup() {
@@ -46,6 +43,11 @@ BUILT_APP="$("$ROOT_DIR/scripts/build-app.sh" "$WORK_DIR/$APP_NAME.app")"
   "$ROOT_DIR/.build/release/capsomnia-pmset" \
   "$PAYLOAD_ROOT/Library/PrivilegedHelperTools/capsomnia-pmset"
 if [[ "$SKIP_SIGNING" != "true" ]]; then
+  # Remove disposable build metadata before signing. Never mutate the signed
+  # app or helper afterward, because doing so invalidates their signatures.
+  /usr/bin/xattr -cr \
+    "$BUILT_APP" \
+    "$PAYLOAD_ROOT/Library/PrivilegedHelperTools/capsomnia-pmset"
   /usr/bin/codesign --force --options runtime --timestamp --sign "$APP_SIGN_ID" "$BUILT_APP"
   /usr/bin/codesign --verify --deep --strict --verbose=2 "$BUILT_APP"
   /usr/bin/codesign \
@@ -168,8 +170,7 @@ EOF
 
 /bin/chmod 0755 "$SCRIPTS_DIR/postinstall"
 
-/usr/bin/xattr -cr "$PAYLOAD_ROOT" "$SCRIPTS_DIR"
-/usr/bin/find "$PAYLOAD_ROOT" -name '._*' -type f -delete
+/usr/bin/xattr -cr "$SCRIPTS_DIR" "$PAYLOAD_ROOT/Library/LaunchAgents"
 
 /usr/bin/env COPYFILE_DISABLE=true /usr/bin/pkgbuild --analyze --root "$PAYLOAD_ROOT" "${PKGBUILD_FILTERS[@]}" "$COMPONENT_PLIST"
 /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" "$COMPONENT_PLIST" 2>/dev/null \
@@ -188,42 +189,29 @@ EOF
   --min-os-version "14.0" \
   "$UNSIGNED_PKG"
 
-EXPANDED_PKG="$WORK_DIR/expanded-pkg"
-PAYLOAD_ARCHIVE="$WORK_DIR/payload.cpio.gz"
-/usr/sbin/pkgutil --expand-full "$UNSIGNED_PKG" "$EXPANDED_PKG"
-/usr/bin/xattr -cr "$EXPANDED_PKG/Payload" "$EXPANDED_PKG/Scripts"
-/usr/bin/find "$EXPANDED_PKG/Payload" -name '._*' -type f -delete
-/usr/bin/lsbom "$EXPANDED_PKG/Bom" \
-  | /usr/bin/awk -F '\t' 'BEGIN { OFS = "\t" } $1 !~ /(^|\/)\._/ { $3 = "0/0"; print }' \
-  > "$BOM_LIST"
-/usr/bin/mkbom -i "$BOM_LIST" "$EXPANDED_PKG/Bom"
-
-payload_file_count="$(/usr/bin/lsbom -s "$EXPANDED_PKG/Bom" | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
-payload_install_kbytes="$(/usr/bin/du -sk "$EXPANDED_PKG/Payload" | /usr/bin/awk '{print $1}')"
-/usr/bin/sed -E -i '' \
-  "s/<payload numberOfFiles=\"[0-9]+\" installKBytes=\"[0-9]+\"\\/>/<payload numberOfFiles=\"$payload_file_count\" installKBytes=\"$payload_install_kbytes\"\\/>/" \
-  "$EXPANDED_PKG/PackageInfo"
-
-(
-  cd "$EXPANDED_PKG/Payload"
-  /usr/bin/find . | /usr/bin/cpio -o -H odc -z -R root:wheel > "$PAYLOAD_ARCHIVE"
-) 2>/dev/null
-/bin/rm -rf "$EXPANDED_PKG/Payload"
-/bin/mv "$PAYLOAD_ARCHIVE" "$EXPANDED_PKG/Payload"
-/usr/sbin/pkgutil --flatten "$EXPANDED_PKG" "$SANITIZED_UNSIGNED_PKG"
-/bin/mv -f "$SANITIZED_UNSIGNED_PKG" "$UNSIGNED_PKG"
-
 VERIFY_PKG="$WORK_DIR/verify-pkg"
 /usr/sbin/pkgutil --expand-full "$UNSIGNED_PKG" "$VERIFY_PKG"
 unexpected_owner="$(/usr/bin/lsbom "$VERIFY_PKG/Bom" | /usr/bin/awk -F '\t' '$3 != "0/0" { print; exit }')"
-appledouble_entry="$(/usr/bin/lsbom -s "$VERIFY_PKG/Bom" | /usr/bin/awk '$0 ~ /(^|\/)\._/ { print; exit }')"
 if [[ -n "$unexpected_owner" ]]; then
   echo "Package payload contains a non-root owner: $unexpected_owner" >&2
   exit 1
 fi
-if [[ -n "$appledouble_entry" ]]; then
-  echo "Package BOM contains an AppleDouble entry: $appledouble_entry" >&2
-  exit 1
+
+# pkgbuild may serialize signature-related extended metadata as AppleDouble
+# entries. Do not strip or repack them: the resulting files must remain exactly
+# as they were when Developer ID signatures were created.
+if [[ "$SKIP_SIGNING" != "true" ]]; then
+  /usr/bin/codesign \
+    --verify \
+    --deep \
+    --strict \
+    --verbose=2 \
+    "$VERIFY_PKG/Payload/Applications/$APP_NAME.app"
+  /usr/bin/codesign \
+    --verify \
+    --strict \
+    --verbose=2 \
+    "$VERIFY_PKG/Payload/Library/PrivilegedHelperTools/capsomnia-pmset"
 fi
 
 if [[ "$SKIP_SIGNING" == "true" ]]; then


### PR DESCRIPTION
## Summary

- stop stripping AppleDouble metadata and manually repacking the `pkgbuild` payload after code signing
- rely on `pkgbuild`'s recommended root ownership instead of rebuilding the BOM and cpio archive
- verify the app and privileged helper signatures from the completed unsigned product archive before applying the Installer signature

## Why

The previous sanitization step mutated signed payload files. The outer package could still be signed and notarized, while the extracted app and helper failed `codesign --verify`.

## Verification

- `zsh -n scripts/build-pkg.sh`
- unsigned package build with `SKIP_SIGNING=true`
- signed package build with Developer ID Application and Installer identities
- independent `pkgutil --expand-full` followed by strict `codesign --verify` for the app and helper
- `pkgutil --check-signature` for the final package
